### PR TITLE
Only lint git files

### DIFF
--- a/lint
+++ b/lint
@@ -166,7 +166,7 @@ function lint_files {
 
 function list_files {
 	if [ $# -gt 0 ]; then
-		find "$@" -type f | grep -vE '(^\./\.git|^\./\.pkg|/vendor/|/node_modules/|\.codecgen\.go$|\.generated\.go$)'
+        git ls-files --exclude-standard | grep -v '^vendor/'
 	else
 		git diff --cached --name-only
 	fi


### PR DESCRIPTION
Means we don't get spurious warnings from generated Javascript files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/build-tools/23)
<!-- Reviewable:end -->
