### PR TITLE
Find files correctly

### DIFF
--- a/files-with-type
+++ b/files-with-type
@@ -10,4 +10,4 @@
 mime_type=$1
 shift
 
-find  "$@" -print0 -type f |xargs -0 file --mime-type | grep "${mime_type}" | sed -e 's/:.*$//'
+git ls-files | grep -vE '^vendor/' | xargs file --mime-type | grep "${mime_type}" | sed -e 's/:.*$//'

--- a/test
+++ b/test
@@ -47,7 +47,7 @@ fi
 
 fail=0
 
-TESTDIRS=( $(find . -type f -name '*_test.go' -print0 | xargs -0 -n1 dirname | grep -vE '^\./(\.git|vendor|prog|experimental)/' | sort -u) )
+TESTDIRS=( $(git ls-files -- '*_test.go' | grep -vE '^(vendor|prog|experimental)/' | xargs -n1 dirname  | sort -u) )
 
 # If running on circle, use the scheduler to work out what tests to run on what shard
 if [ -n "$CIRCLECI" ] && [ -z "$NO_SCHEDULER" ] && [ -x "$DIR/sched" ]; then

--- a/test
+++ b/test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GO_TEST_ARGS=( -tags netgo -cpu 4 -timeout 8m )


### PR DESCRIPTION
Updates a couple of the places where we use `find` to use `git ls-files` instead: it's faster and closer to what we actually want.

Updates shell linting to ignore vendoring. I'm not super happy with it, but I'd like to get this in quickly, get linting running on everything, *then* rewrite all this stuff in a real language.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/build-tools/24)
<!-- Reviewable:end -->
