### PR TITLE
Properly exclude vendor from lint

### DIFF
--- a/files-with-type
+++ b/files-with-type
@@ -10,4 +10,4 @@
 mime_type=$1
 shift
 
-git ls-files | grep -vE '^vendor/' | xargs file --mime-type | grep "${mime_type}" | sed -e 's/:.*$//'
+git ls-files "$@" | grep -vE '^vendor/' | xargs file --mime-type | grep "${mime_type}" | sed -e 's/:.*$//'

--- a/files-with-type
+++ b/files-with-type
@@ -4,8 +4,6 @@
 #
 # e.g.
 #     $ files-with-type text/x-shellscript k8s infra
-#
-# Assumes `find`, `xargs`, and `file` are all installed.
 
 mime_type=$1
 shift

--- a/lint
+++ b/lint
@@ -166,7 +166,7 @@ function lint_files {
 
 function list_files {
 	if [ $# -gt 0 ]; then
-        git ls-files --exclude-standard | grep -v '^vendor/'
+        git ls-files --exclude-standard | grep -vE '(^|/)vendor/'
 	else
 		git diff --cached --name-only
 	fi


### PR DESCRIPTION
Also, only run `shell-lint` over specified directories. Fixes build failures in scope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/build-tools/26)
<!-- Reviewable:end -->
