### PR TITLE
Import image-tag script into build tools so it can be shared

### DIFF
--- a/image-tag
+++ b/image-tag
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+WORKING_SUFFIX=$(if ! git diff --exit-code --quiet HEAD >&2; \
+                 then echo "-WIP"; \
+                 else echo ""; \
+                 fi)
+BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
+echo "${BRANCH_PREFIX//\//-}-$(git rev-parse --short HEAD)$WORKING_SUFFIX"


### PR DESCRIPTION
We have divergent versions of this script across repos.
This particular version comes from 6334836@scope.
We in particular want this version's changes to support branches
with a '/' character in them.

Once this PR is merged, we can begin making changes to other repos to use
this repo's version instead of their own.