### PR TITLE
shell-lint: Don't fail if no shell scripts found

### DIFF
--- a/shell-lint
+++ b/shell-lint
@@ -10,4 +10,4 @@
 # - files-with-type
 # - file >= 5.22
 
-"$(dirname "${BASH_SOURCE[0]}")/files-with-type" text/x-shellscript "$@" | xargs shellcheck
+"$(dirname "${BASH_SOURCE[0]}")/files-with-type" text/x-shellscript "$@" | xargs --no-run-if-empty shellcheck


### PR DESCRIPTION
This fixes the case where the provided paths do not contain any shell scripts,
ie. xargs is passed no values.
In this case by default, xargs invokes the command once with no args.
This causes shellcheck to print usage and exit failure.
The GNU-specific --no-run-if-empty changes the behaviour so that in this case,
shellcheck is simply never run.

This allows us to use this script as a general lint even in contexts where
no shell scripts are present, or none of the files passed are shell scripts.