### PR TITLE
integrations: Fix a shellcheck linter error

### DIFF
--- a/integration/gce.sh
+++ b/integration/gce.sh
@@ -39,6 +39,7 @@ function vm_names {
 
 # Delete all vms in this account
 function destroy {
+	local names
 	names="$(vm_names)"
 	if [ "$(gcloud compute instances list --zone "$ZONE" -q "$names" | wc -l)" -le 1 ] ; then
 		return 0


### PR DESCRIPTION
A harmless (for now) bug where `names` global was being modified when
a local was intended.