### PR TITLE
Use mflag package from weaveworks fork until we find a better solution

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/docker/pkg/mflag"
 	"github.com/mgutz/ansi"
+	"github.com/weaveworks/docker/pkg/mflag"
 )
 
 const (

--- a/socks/main.go
+++ b/socks/main.go
@@ -9,7 +9,7 @@ import (
 	"text/template"
 
 	socks5 "github.com/armon/go-socks5"
-	"github.com/docker/docker/pkg/mflag"
+	"github.com/weaveworks/docker/pkg/mflag"
 	"github.com/weaveworks/weave/common/mflagext"
 	"golang.org/x/net/context"
 )


### PR DESCRIPTION
Temporary fix for https://github.com/weaveworks/build-tools/issues/38 

We should probably start using cobra instead.

