### PR TITLE
Check if SHA1 exists before calling `git diff`on it

### DIFF
--- a/rebuild-image
+++ b/rebuild-image
@@ -40,9 +40,22 @@ commit_timestamp() {
 	git show -s --format=%ct "$rev"
 }
 
+# Is the SHA1 actually present in the repo?
+# It could be it isn't, e.g. after a force push
+is_valid_commit() {
+	local rev=$1
+	git rev-parse --quiet --verify "$rev^{commit}" > /dev/null
+}
+
 cached_revision=$(cached_image_rev)
 if [ -z "$cached_revision" ]; then
 	echo ">>> No cached image found; rebuilding"
+	rebuild
+	exit 0
+fi
+
+if ! is_valid_commit "$cached_revision"; then
+	echo ">>> Git commit of cached image not found in repo; rebuilding"
 	rebuild
 	exit 0
 fi


### PR DESCRIPTION
In the case of a force push, the commit will not exist anymore, and the
`git diff` in `has_changes` will fail, but the failure would be silently
ignored (since the error message would be passed to `wc`).

`wc -l` would return 1, so effectively the same image would be reused
over and over.