### PR TITLE
Don't over write lint_result with 0 when shellcheck succeeds

### DIFF
--- a/integration/assert.sh
+++ b/integration/assert.sh
@@ -91,7 +91,8 @@ assert_end() {
     #   ${tests_time:0:${#tests_time}-9} - seconds
     #   ${tests_time:${#tests_time}-9:3} - milliseconds
     if [[ -z "$INVARIANT" ]]; then
-        report_time=" in ${tests_time:0:${#tests_time}-9}.${tests_time:${#tests_time}-9:3}s"
+        idx=$((${#tests_time} - 9))
+        report_time=" in ${tests_time:0:${idx}}.${tests_time:${idx}:3}s"
     else
         report_time=
     fi

--- a/lint
+++ b/lint
@@ -139,8 +139,7 @@ lint_sh() {
     # the shellcheck is completely optional.  If you don't like it
     # don't have it installed.
     if type shellcheck >/dev/null 2>&1; then
-        shellcheck "${filename}"
-        lint_result=$?
+        shellcheck "${filename}" || lint_result=1
     fi
 
     return $lint_result


### PR DESCRIPTION
Fixes #46