### PR TITLE
Make no-go-get the default, and don't assume -tags netgo

### DIFF
--- a/test
+++ b/test
@@ -6,6 +6,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SLOW=
 NO_GO_GET=true
 TAGS=
+PARALLEL=
 
 usage() {
     echo "$0 [-slow] [-in-container foo] [-netgo] [-(no-)go-get]"
@@ -27,6 +28,10 @@ while [ $# -gt 0 ]; do
             ;;
         "-netgo")
             TAGS="-tags netgo"
+            shift 1
+            ;;
+        "-p")
+            PARALLEL=true
             shift 1
             ;;
         *)
@@ -79,32 +84,45 @@ PACKAGE_BASE=$(go list -e ./)
 # Speed up the tests by compiling and installing their dependencies first.
 go test -i "${GO_TEST_ARGS[@]}" "${TESTDIRS[@]}"
 
-for dir in "${TESTDIRS[@]}"; do
+run_test() {
+    local dir=$1
     if [ -z "$NO_GO_GET" ]; then
         go get -t $TAGS "$dir"
     fi
 
-    GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}")
+    local GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}")
     if [ -n "$SLOW" ]; then
-        COVERPKGS=$( (
+        local COVERPKGS=$( (
             go list "$dir"
             go list -f '{{join .Deps "\n"}}' "$dir" | grep -v "vendor" | grep "^$PACKAGE_BASE/"
         ) | paste -s -d, -)
-        output=$(mktemp "$coverdir/unit.XXXXXXXXXX")
-        GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}" -coverprofile=$output -coverpkg=$COVERPKGS)
+        local output=$(mktemp "$coverdir/unit.XXXXXXXXXX")
+        local GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}" -coverprofile=$output -coverpkg=$COVERPKGS)
     fi
 
-    START=$(date +%s)
+    local START=$(date +%s)
     if ! go test "${GO_TEST_ARGS_RUN[@]}" "$dir"; then
         fail=1
     fi
-    RUNTIME=$(($(date +%s) - START))
+    local RUNTIME=$(($(date +%s) - START))
 
     # Report test runtime when running on circle, to help scheduler
     if [ -n "$CIRCLECI" ] && [ -z "$NO_SCHEDULER" ] && [ -x "$DIR/sched" ]; then
         "$DIR/sched" time "$dir" "$RUNTIME"
     fi
+}
+
+for dir in "${TESTDIRS[@]}"; do
+    if [ -n "$PARALLEL" ]; then
+        run_test "$dir" &
+    else
+        run_test "$dir"
+    fi
 done
+
+if [ -n "$PARALLEL" ]; then
+    wait
+fi
 
 if [ -n "$SLOW" ] && [ -z "$COVERDIR" ]; then
     go get github.com/weaveworks/tools/cover

--- a/test
+++ b/test
@@ -3,12 +3,12 @@
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-GO_TEST_ARGS=(-tags netgo -cpu 4 -timeout 8m)
 SLOW=
-NO_GO_GET=
+NO_GO_GET=true
+TAGS=
 
 usage() {
-    echo "$0 [-slow] [-in-container foo]"
+    echo "$0 [-slow] [-in-container foo] [-netgo] [-(no-)go-get]"
 }
 
 while [ $# -gt 0 ]; do
@@ -21,12 +21,22 @@ while [ $# -gt 0 ]; do
             NO_GO_GET=true
             shift 1
             ;;
+        "-go-get")
+            NO_GO_GET=
+            shift 1
+            ;;
+        "-netgo")
+            TAGS="-tags netgo"
+            shift 1
+            ;;
         *)
             usage
             exit 2
             ;;
     esac
 done
+
+GO_TEST_ARGS=($TAGS -cpu 4 -timeout 8m)
 
 if [ -n "$SLOW" ] || [ -n "$CIRCLECI" ]; then
     SLOW=true
@@ -71,7 +81,7 @@ go test -i "${GO_TEST_ARGS[@]}" "${TESTDIRS[@]}"
 
 for dir in "${TESTDIRS[@]}"; do
     if [ -z "$NO_GO_GET" ]; then
-        go get -t -tags netgo "$dir"
+        go get -t $TAGS "$dir"
     fi
 
     GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}")


### PR DESCRIPTION
If we don't assume tags=netgo, then we can use ./tools/test where we can't write to the go install (for instance, on your mac).  