### PR TITLE
Revert "Make no-go-get the default, and don't assume -tags netgo"

### DIFF
--- a/test
+++ b/test
@@ -3,13 +3,12 @@
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GO_TEST_ARGS=(-tags netgo -cpu 4 -timeout 8m)
 SLOW=
-NO_GO_GET=true
-TAGS=
-PARALLEL=
+NO_GO_GET=
 
 usage() {
-    echo "$0 [-slow] [-in-container foo] [-netgo] [-(no-)go-get]"
+    echo "$0 [-slow] [-in-container foo]"
 }
 
 while [ $# -gt 0 ]; do
@@ -22,26 +21,12 @@ while [ $# -gt 0 ]; do
             NO_GO_GET=true
             shift 1
             ;;
-        "-go-get")
-            NO_GO_GET=
-            shift 1
-            ;;
-        "-netgo")
-            TAGS="-tags netgo"
-            shift 1
-            ;;
-        "-p")
-            PARALLEL=true
-            shift 1
-            ;;
         *)
             usage
             exit 2
             ;;
     esac
 done
-
-GO_TEST_ARGS=($TAGS -cpu 4 -timeout 8m)
 
 if [ -n "$SLOW" ] || [ -n "$CIRCLECI" ]; then
     SLOW=true
@@ -84,45 +69,32 @@ PACKAGE_BASE=$(go list -e ./)
 # Speed up the tests by compiling and installing their dependencies first.
 go test -i "${GO_TEST_ARGS[@]}" "${TESTDIRS[@]}"
 
-run_test() {
-    local dir=$1
+for dir in "${TESTDIRS[@]}"; do
     if [ -z "$NO_GO_GET" ]; then
-        go get -t $TAGS "$dir"
+        go get -t -tags netgo "$dir"
     fi
 
-    local GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}")
+    GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}")
     if [ -n "$SLOW" ]; then
-        local COVERPKGS=$( (
+        COVERPKGS=$( (
             go list "$dir"
             go list -f '{{join .Deps "\n"}}' "$dir" | grep -v "vendor" | grep "^$PACKAGE_BASE/"
         ) | paste -s -d, -)
-        local output=$(mktemp "$coverdir/unit.XXXXXXXXXX")
-        local GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}" -coverprofile=$output -coverpkg=$COVERPKGS)
+        output=$(mktemp "$coverdir/unit.XXXXXXXXXX")
+        GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}" -coverprofile=$output -coverpkg=$COVERPKGS)
     fi
 
-    local START=$(date +%s)
+    START=$(date +%s)
     if ! go test "${GO_TEST_ARGS_RUN[@]}" "$dir"; then
         fail=1
     fi
-    local RUNTIME=$(($(date +%s) - START))
+    RUNTIME=$(($(date +%s) - START))
 
     # Report test runtime when running on circle, to help scheduler
     if [ -n "$CIRCLECI" ] && [ -z "$NO_SCHEDULER" ] && [ -x "$DIR/sched" ]; then
         "$DIR/sched" time "$dir" "$RUNTIME"
     fi
-}
-
-for dir in "${TESTDIRS[@]}"; do
-    if [ -n "$PARALLEL" ]; then
-        run_test "$dir" &
-    else
-        run_test "$dir"
-    fi
 done
-
-if [ -n "$PARALLEL" ]; then
-    wait
-fi
 
 if [ -n "$SLOW" ] && [ -z "$COVERDIR" ]; then
     go get github.com/weaveworks/tools/cover


### PR DESCRIPTION
Reverts weaveworks/build-tools#61

Was causing issues like:

```
docker run  -ti \
		-v /home/ubuntu/cortex/.pkg:/go/pkg \
		-v /home/ubuntu/cortex:/go/src/github.com/weaveworks/cortex \
		weaveworks/cortex-build test
make: Entering directory '/go/src/github.com/weaveworks/cortex'

protoc -I ./vendor:. --go_out=plugins=grpc:. ./cortex.proto

./tools/test -no-go-get

go install net: open /usr/local/go/pkg/linux_amd64/net.a: permission denied

Makefile:84: recipe for target 'test' failed

make: *** [test] Error 1

make: Leaving directory '/go/src/github.com/weaveworks/cortex'

make: *** [test] Error 2

make RM= test returned exit code 2
```