### PR TITLE
Remove test package linting

### DIFF
--- a/lint
+++ b/lint
@@ -25,6 +25,9 @@ while true; do
             IGNORE_LINT_COMMENT=1
             shift 1
             ;;
+        -notestpackage)
+	    # NOOP, still accepted for backwards compatibility
+            shift 1
         -ignorespelling)
             IGNORE_SPELLINGS="$2,$IGNORE_SPELLINGS"
             shift 2

--- a/lint
+++ b/lint
@@ -18,16 +18,11 @@
 set -e
 
 IGNORE_LINT_COMMENT=
-IGNORE_TEST_PACKAGES=
 IGNORE_SPELLINGS=
 while true; do
     case "$1" in
         -nocomment)
             IGNORE_LINT_COMMENT=1
-            shift 1
-            ;;
-        -notestpackage)
-            IGNORE_TEST_PACKAGES=1
             shift 1
             ;;
         -ignorespelling)
@@ -60,30 +55,6 @@ spell_check() {
 
     if ! misspell -error -i "$IGNORE_SPELLINGS" "${filename}"; then
         lint_result=1
-    fi
-
-    return $lint_result
-}
-
-test_mismatch() {
-    local filename="$1"
-    local package=$(grep '^package ' "$filename" | awk '{print $2}')
-    local lint_result=0
-
-    if [[ $package == "main" ]]; then
-        return # in package main, all bets are off
-    fi
-
-    if [[ $filename == *"_internal_test.go" ]]; then
-        if [[ $package == *"_test" ]]; then
-            lint_result=1
-            echo "${filename}: should not be part of a _test package"
-        fi
-    else
-        if [[ ! $package == *"_test" ]]; then
-            lint_result=1
-            echo "${filename}: should be part of a _test package"
-        fi
     fi
 
     return $lint_result
@@ -182,12 +153,6 @@ lint() {
         sh) lint_sh "${filename}" || lint_result=1 ;;
         tf) lint_tf "${filename}" || lint_result=1 ;;
     esac
-
-    if [ -z "$IGNORE_TEST_PACKAGES" ]; then
-        if [[ "$filename" == *"_test.go" ]]; then
-            test_mismatch "${filename}" || lint_result=1
-        fi
-    fi
 
     spell_check "${filename}" || lint_result=1
 


### PR DESCRIPTION
Having _test packages leads to unnecessary symbol exports