### PR TITLE
Reduce test timeout

### DIFF
--- a/test
+++ b/test
@@ -7,9 +7,10 @@ SLOW=
 NO_GO_GET=true
 TAGS=
 PARALLEL=
+TIMEOUT=1m
 
 usage() {
-    echo "$0 [-slow] [-in-container foo] [-netgo] [-(no-)go-get]"
+    echo "$0 [-slow] [-in-container foo] [-netgo] [-(no-)go-get] [-timeout 1m]"
 }
 
 while [ $# -gt 0 ]; do
@@ -34,6 +35,10 @@ while [ $# -gt 0 ]; do
             PARALLEL=true
             shift 1
             ;;
+        "-timeout")
+            TIMEOUT=$2
+            shift 2
+            ;;
         *)
             usage
             exit 2
@@ -41,7 +46,7 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-GO_TEST_ARGS=($TAGS -cpu 4 -timeout 1m)
+GO_TEST_ARGS=($TAGS -cpu 4 -timeout $TIMEOUT)
 
 if [ -n "$SLOW" ] || [ -n "$CIRCLECI" ]; then
     SLOW=true

--- a/test
+++ b/test
@@ -41,7 +41,7 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-GO_TEST_ARGS=($TAGS -cpu 4 -timeout 8m)
+GO_TEST_ARGS=($TAGS -cpu 4 -timeout 1m)
 
 if [ -n "$SLOW" ] || [ -n "$CIRCLECI" ]; then
     SLOW=true


### PR DESCRIPTION
Given that we split repos when test suites take too long, we might as well lower the timeout that we use for tests.

This has the benefit of accelerating local development when encountering deadlocked or infinite looping code.