### PR TITLE
Add support for .lintignore.

### DIFF
--- a/lint
+++ b/lint
@@ -17,6 +17,8 @@
 
 set -e
 
+LINT_IGNORE_FILE=${LINT_IGNORE_FILE:-".lintignore"}
+
 IGNORE_LINT_COMMENT=
 IGNORE_SPELLINGS=
 while true; do
@@ -172,6 +174,33 @@ lint_files() {
     exit $lint_result
 }
 
+matches_any() {
+    local filename="$1"
+    local patterns="$2"
+    while read -r pattern; do
+        # shellcheck disable=SC2053
+        # Use the [[ operator without quotes on $pattern 
+        # in order to "glob" the provided filename:
+        [[ "$filename" == $pattern ]] && return 0
+    done <<<"$patterns"
+    return 1
+}
+
+filter_out() {
+    local patterns_file="$1"
+    if [ -n "$patterns_file" ] && [ -r "$patterns_file" ]; then
+        local patterns=$(sed '/^#.*$/d ; /^\s*$/d' "$patterns_file") # Remove blank lines and comments before we start iterating.
+        [ -n "$DEBUG" ] && echo >&2 "> Filters:" && echo >&2 "$patterns"
+        local filtered_out=()
+        while read -r filename; do
+            matches_any "$filename" "$patterns" && filtered_out+=("$filename") || echo "$filename"
+        done
+        [ -n "$DEBUG" ] && echo >&2 "> Files filtered out (i.e. NOT linted):" && printf >&2 '%s\n' "${filtered_out[@]}"
+    else
+        cat # No patterns provided: simply propagate stdin to stdout.
+    fi
+}
+
 list_files() {
     if [ $# -gt 0 ]; then
         git ls-files --exclude-standard | grep -vE '(^|/)vendor/'
@@ -180,4 +209,4 @@ list_files() {
     fi
 }
 
-list_files "$@" | lint_files
+list_files "$@" | filter_out "$LINT_IGNORE_FILE" | lint_files


### PR DESCRIPTION
Lint-ing all of Weave Net is currently not desirable because: 

* it would create conflicts on many branches,
* it would pollute the git history, 
* etc. 

and because `lint` currently lints all files except `./vendor`, this breaks Weave Net's build.
As a result, Weave Net is not using the latest commit in `build-tools`'s `master` branch, which is also source of problems:

* it limits standardisation of projects across Weaveworks, 
* it limits the ability to use the latest features of `build-tools`, 
* it complexifies merging changes in `build-tools` (e.g. #53 and weaveworks/weave#2694 for weaveworks/weave#2647), 
* etc.

This change adds the ability to optionally process a `.lintignore` file, which can contain any number of `GLOB`s then used to filter out files one does not want to lint, a-la `.gitignore`.
This, coupled with a `.lintignore` file in Weave Net will then enable Weave Net to use the latest version of `build-tools`.