### PR TITLE
Add -p option to parallelise lint.

### DIFF
--- a/lint
+++ b/lint
@@ -21,6 +21,7 @@ LINT_IGNORE_FILE=${LINT_IGNORE_FILE:-".lintignore"}
 
 IGNORE_LINT_COMMENT=
 IGNORE_SPELLINGS=
+PARALLEL=
 while true; do
     case "$1" in
         -nocomment)
@@ -34,6 +35,10 @@ while true; do
         -ignorespelling)
             IGNORE_SPELLINGS="$2,$IGNORE_SPELLINGS"
             shift 2
+            ;;
+        -p)
+            PARALLEL=1
+            shift 1
             ;;
         *)
             break
@@ -179,7 +184,7 @@ matches_any() {
     local patterns="$2"
     while read -r pattern; do
         # shellcheck disable=SC2053
-        # Use the [[ operator without quotes on $pattern 
+        # Use the [[ operator without quotes on $pattern
         # in order to "glob" the provided filename:
         [[ "$filename" == $pattern ]] && return 0
     done <<<"$patterns"
@@ -203,10 +208,16 @@ filter_out() {
 
 list_files() {
     if [ $# -gt 0 ]; then
-        git ls-files --exclude-standard | grep -vE '(^|/)vendor/'
+        find "$@" | grep -vE '(^|/)vendor/'
     else
-        git diff --cached --name-only
+        git ls-files --exclude-standard | grep -vE '(^|/)vendor/'
     fi
 }
 
-list_files "$@" | filter_out "$LINT_IGNORE_FILE" | lint_files
+if [ $# = 1 ] && [ -f "$1" ]; then
+    lint "$1"
+elif [ -n "$PARALLEL" ]; then
+    list_files "$@" | filter_out "$LINT_IGNORE_FILE" | xargs -n1 -P16 $0
+else
+    list_files "$@" | filter_out "$LINT_IGNORE_FILE" | lint_files
+fi


### PR DESCRIPTION
On cortex, >60% saving.

```
Toms-MacBook-Pro:cortex twilkie$ time ./tools/lint 
push-images: run shfmt -i 4 -w push-images
tools/lint: run shfmt -i 4 -w tools/lint

real	0m10.466s
user	0m5.115s
sys	0m4.070s
Toms-MacBook-Pro:cortex twilkie$ time ./tools/lint -p
push-images: run shfmt -i 4 -w push-images
tools/lint: run shfmt -i 4 -w tools/lint

real	0m4.366s
user	0m7.121s
sys	0m5.434s
```