### PR TITLE
Set current dir using BASH_SOURCE.

### DIFF
--- a/provisioning/setup.sh
+++ b/provisioning/setup.sh
@@ -329,7 +329,7 @@ Examples:
   $ tf_ansi 1 -vvv
 Available playbooks:
 EOF
-    cat -n >&2 <<<"$(for file in "$(dirname "$0")"/../../config_management/*.yml; do basename "$file" | sed 's/.yml//'; done)"
+    cat -n >&2 <<<"$(for file in "$(dirname "${BASH_SOURCE[0]}")"/../../config_management/*.yml; do basename "$file" | sed 's/.yml//'; done)"
 }
 
 # shellcheck disable=SC2155,SC2064
@@ -341,10 +341,10 @@ function tf_ansi() {
         local playbooks=(../../config_management/*.yml)
         local path="${playbooks[(($id-1))]}" # Select the ith entry in the list of playbooks (0-based).
     else
-        local path="$(dirname "$0")/../../config_management/$id.yml"
+        local path="$(dirname "${BASH_SOURCE[0]}")/../../config_management/$id.yml"
     fi
     local inventory="$(mktemp /tmp/ansible_inventory_XXX)"
-    trap 'rm $inventory' SIGINT SIGTERM RETURN
+    trap 'rm -f $inventory' SIGINT SIGTERM RETURN
     echo -e "$(terraform output ansible_inventory)" >"$inventory"
     [ ! -r "$path" ] && tf_ansi_usage "Ansible playbook not found: $path" && return 1
     ansible-playbook "$@" -u "$(terraform output username)" -i "$inventory" --ssh-extra-args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" "$path"


### PR DESCRIPTION
This makes the setup.sh script work more consistently: 

- under both Linux and macOS, and 
- whether you source it or execute it.