### PR TITLE
integration/config: fix weave path etc.

### DIFF
--- a/integration/config.sh
+++ b/integration/config.sh
@@ -130,4 +130,4 @@ end_suite() {
     whitely assert_end
 }
 
-WEAVE=$DIR/../weave
+WEAVE=$DIR/../../integration/weave

--- a/integration/gce.sh
+++ b/integration/gce.sh
@@ -9,7 +9,8 @@ set -e
 
 : "${KEY_FILE:=/tmp/gce_private_key.json}"
 : "${SSH_KEY_FILE:=$HOME/.ssh/gce_ssh_key}"
-: "${IMAGE:=ubuntu-14-04}"
+: "${IMAGE_FAMILY:=ubuntu-1404-lts}"
+: "${IMAGE_PROJECT:=ubuntu-os-cloud}"
 : "${USER_ACCOUNT:=ubuntu}"
 : "${ZONE:=us-central1-a}"
 : "${PROJECT:=}"
@@ -144,7 +145,7 @@ function setup() {
 }
 
 function make_template() {
-    gcloud compute instances create "$TEMPLATE_NAME" --image "$IMAGE" --zone "$ZONE"
+    gcloud compute instances create "$TEMPLATE_NAME" --image-family "$IMAGE_FAMILY" --image-project "$IMAGE_PROJECT" --zone "$ZONE"
     gcloud compute config-ssh --ssh-key-file "$SSH_KEY_FILE"
     name="$TEMPLATE_NAME.$ZONE.$PROJECT"
     try_connect "$name"

--- a/integration/sanity_check.sh
+++ b/integration/sanity_check.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# shellcheck disable=SC1091
+# shellcheck disable=SC1090,SC1091
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/config.sh"
 
 set -e

--- a/provisioning/setup.sh
+++ b/provisioning/setup.sh
@@ -313,7 +313,8 @@ function tf_ssh() {
     local ip="$(sed "$1q;d" <<<"$(terraform output public_etc_hosts)" | cut -d ' ' -f 1)"
     shift # Drop the first argument, corresponding to the machine ID, to allow passing other arguments to SSH using "$@" -- see below.
     [ -z "$ip" ] && tf_ssh_usage "Invalid host ID provided." && return 1
-    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$@" "$(terraform output username)"@"$ip"
+    # shellcheck disable=SC2029
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$@" "$(terraform output username)@$ip"
 }
 alias tf_ssh='tf_ssh'
 


### PR DESCRIPTION
Please note: cc02224 assumes `integration/config.sh` is only used in the context of Scope's integration tests. Is that actually correct?

xref https://github.com/weaveworks/scope/pull/2225