### PR TITLE
Change Python shebang to `#!/usr/bin/env python`

### DIFF
--- a/dependencies/cross_versions.py
+++ b/dependencies/cross_versions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Generate the cross product of latest versions of Weave Net's dependencies:
 # - Go

--- a/dependencies/list_versions.py
+++ b/dependencies/list_versions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # List all available versions of Weave Net's dependencies:
 # - Go

--- a/sched
+++ b/sched
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import sys, string, urllib
 import requests
 import optparse


### PR DESCRIPTION
.. to allow use of virtual environments and install up-to-date
dependencies.

We stumbled over this when trying to update python-requests for the
Scope build-tools update which includes

https://github.com/weaveworks/build-tools/pull/73/commits/3e863df9bee7567300d3c2d11203ba0d182f7808

and expects python-requests >= 2.4.2.