### PR TITLE
Secure GCP servers for Scope.

### DIFF
--- a/integration/gce.sh
+++ b/integration/gce.sh
@@ -44,6 +44,10 @@ function vm_names() {
 # Delete all vms in this account
 function destroy() {
     local names
+    # shellcheck disable=SC2046
+    if [ $(gcloud compute firewall-rules list "test-allow-docker$SUFFIX" 2>/dev/null | wc -l) -gt 0 ]; then
+        gcloud compute firewall-rules delete "test-allow-docker$SUFFIX"
+    fi
     names="$(vm_names)"
     # shellcheck disable=SC2086
     if [ "$(gcloud compute instances list --zones "$ZONE" -q $names | wc -l)" -le 1 ]; then
@@ -116,7 +120,10 @@ function setup() {
     destroy
 
     names=($(vm_names))
-    gcloud compute instances create "${names[@]}" --image "$TEMPLATE_NAME" --zone "$ZONE"
+    gcloud compute instances create "${names[@]}" --image "$TEMPLATE_NAME" --zone "$ZONE" --tags "test$SUFFIX" --network=test
+    my_ip="$(curl -s http://ipinfo.io/ip)"
+    gcloud compute firewall-rules create "test-allow-docker$SUFFIX" --network=test --allow tcp:2375,tcp:12375,tcp:4040 --target-tags "test$SUFFIX" --source-ranges "$my_ip"
+
     gcloud compute config-ssh --ssh-key-file "$SSH_KEY_FILE"
     sed -i '/UserKnownHostsFile=\/dev\/null/d' ~/.ssh/config
 

--- a/integration/gce.sh
+++ b/integration/gce.sh
@@ -122,7 +122,7 @@ function setup() {
     names=($(vm_names))
     gcloud compute instances create "${names[@]}" --image "$TEMPLATE_NAME" --zone "$ZONE" --tags "test$SUFFIX" --network=test
     my_ip="$(curl -s http://ipinfo.io/ip)"
-    gcloud compute firewall-rules create "test-allow-docker$SUFFIX" --network=test --allow tcp:2375,tcp:12375,tcp:4040 --target-tags "test$SUFFIX" --source-ranges "$my_ip"
+    gcloud compute firewall-rules create "test-allow-docker$SUFFIX" --network=test --allow tcp:2375,tcp:12375,tcp:4040,tcp:80 --target-tags "test$SUFFIX" --source-ranges "$my_ip"
 
     gcloud compute config-ssh --ssh-key-file "$SSH_KEY_FILE"
     sed -i '/UserKnownHostsFile=\/dev\/null/d' ~/.ssh/config


### PR DESCRIPTION
Should help prevent testing VMs to be used for DOS attacks.
N.B.: not tested.