### PR TITLE
Add support for "unstable" and 1.6 versions of Kubernetes to dev/test infrastructure

### DIFF
--- a/config_management/group_vars/all
+++ b/config_management/group_vars/all
@@ -4,7 +4,7 @@ terraform_version: 0.8.5
 docker_version: 1.11.2
 kubernetes_version: 1.5.2
 kubernetes_cni_version: 0.3.0.1
-kubernetes_token: 123456.0123456789123456
+kubernetes_token: '123456.0123456789123456'
 etcd_container_version: 2.2.5
 kube_discovery_container_version: 1.0
 pause_container_version: 3.0

--- a/config_management/roles/dev-tools/tasks/main.yml
+++ b/config_management/roles/dev-tools/tasks/main.yml
@@ -5,7 +5,7 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: 
+  with_items:
     # weave net dependencies
     - make
     - vagrant

--- a/config_management/roles/docker-configuration/tasks/main.yml
+++ b/config_management/roles/docker-configuration/tasks/main.yml
@@ -26,7 +26,7 @@
   register: docker_over_tcp
 
 - name: restart docker service
-  systemd: 
+  systemd:
     name: docker
     state: restarted
     daemon_reload: yes  # ensure docker_over_tcp.conf is picked up.

--- a/config_management/roles/docker-from-docker-repo/tasks/debian.yml
+++ b/config_management/roles/docker-from-docker-repo/tasks/debian.yml
@@ -5,12 +5,12 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: 
+  with_items:
     - apt-transport-https
     - ca-certificates
 
 - name: add apt key for the docker repository
-  apt_key: 
+  apt_key:
     keyserver: hkp://ha.pool.sks-keyservers.net:80
     id: 58118E89F3A912897C070ADBF76221572C52609D
     state: present
@@ -23,7 +23,7 @@
   register: apt_docker_repo
 
 - name: update apt's cache
-  apt: 
+  apt:
     update_cache: yes
   when: apt_key_docker_repo.changed or apt_docker_repo.changed
 
@@ -31,5 +31,5 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: 
+  with_items:
     - docker-engine={{ docker_version }}*

--- a/config_management/roles/docker-from-docker-repo/tasks/redhat.yml
+++ b/config_management/roles/docker-from-docker-repo/tasks/redhat.yml
@@ -13,7 +13,7 @@
     state: present
 
 - name: update yum's cache
-  yum: 
+  yum:
     name: "*"
     update_cache: yes
 
@@ -21,5 +21,5 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: 
+  with_items:
     - docker-engine-{{ docker_version }}

--- a/config_management/roles/docker-from-tarball/tasks/main.yml
+++ b/config_management/roles/docker-from-tarball/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Set up Docker
-# See also: 
+# See also:
 # - https://docs.docker.com/engine/installation/linux/ubuntulinux/#install
 # - https://github.com/docker/docker/releases
 

--- a/config_management/roles/docker-prerequisites/tasks/debian.yml
+++ b/config_management/roles/docker-prerequisites/tasks/debian.yml
@@ -6,6 +6,6 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: 
+  with_items:
     - linux-image-extra-{{ ansible_kernel }}
     - linux-image-extra-virtual

--- a/config_management/roles/golang-from-tarball/tasks/main.yml
+++ b/config_management/roles/golang-from-tarball/tasks/main.yml
@@ -19,7 +19,7 @@
     create: yes
     mode: 0644
   become: '{{ item }}'
-  with_items: 
+  with_items:
     - true  # Run as root
     - false # Run as SSH user
 
@@ -31,6 +31,6 @@
     create: yes
     mode: 0644
   become: '{{ item }}'
-  with_items: 
+  with_items:
     - true  # Run as root
-    - false # Run as SSH user    
+    - false # Run as SSH user

--- a/config_management/roles/kubelet-stop/tasks/main.yml
+++ b/config_management/roles/kubelet-stop/tasks/main.yml
@@ -6,7 +6,7 @@
   register: kubelet
 
 # avoids having weave-net and weave-kube conflict in some test cases (e.g. 130_expose_test.sh)
-- name: stop kubelet service 
+- name: stop kubelet service
   systemd:
     name: kubelet
     state: stopped

--- a/config_management/roles/kubernetes-install/tasks/debian.yml
+++ b/config_management/roles/kubernetes-install/tasks/debian.yml
@@ -12,6 +12,14 @@
     repo: deb http://apt.kubernetes.io/ kubernetes-{{ ansible_distribution_release }} main
     state: present
   register: apt_k8s_repo
+  when: '"alpha" not in kubernetes_version and "beta" not in kubernetes_version'
+
+- name: add kubernetes' apt repository (kubernetes-{{ ansible_distribution_release }}-unstable)
+  apt_repository:
+    repo: deb http://apt.kubernetes.io/ kubernetes-{{ ansible_distribution_release }}-unstable main
+    state: present
+  register: apt_k8s_repo
+  when: '"alpha" in kubernetes_version or "beta" in kubernetes_version'
 
 - name: update apt's cache
   apt: 

--- a/config_management/roles/kubernetes-install/tasks/debian.yml
+++ b/config_management/roles/kubernetes-install/tasks/debian.yml
@@ -2,7 +2,7 @@
 # Debian / Ubuntu specific:
 
 - name: add apt key for the kubernetes repository
-  apt_key: 
+  apt_key:
     url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
     state: present
   register: apt_key_k8s_repo
@@ -22,7 +22,7 @@
   when: '"alpha" in kubernetes_version or "beta" in kubernetes_version'
 
 - name: update apt's cache
-  apt: 
+  apt:
     update_cache: yes
   when: apt_key_k8s_repo.changed or apt_k8s_repo.changed
 
@@ -30,7 +30,7 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: 
+  with_items:
     - kubelet={{ kubernetes_version }}*
     - kubectl={{ kubernetes_version }}*
     - kubernetes-cni={{ kubernetes_cni_version }}*

--- a/config_management/roles/kubernetes-install/tasks/main.yml
+++ b/config_management/roles/kubernetes-install/tasks/main.yml
@@ -12,6 +12,6 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: 
+  with_items:
     - ebtables
     - kubeadm

--- a/config_management/roles/kubernetes-install/tasks/redhat.yml
+++ b/config_management/roles/kubernetes-install/tasks/redhat.yml
@@ -14,7 +14,7 @@
   register: yum_k8s_repo
 
 - name: update yum's cache
-  yum: 
+  yum:
     name: "*"
     update_cache: yes
   when: yum_k8s_repo.changed
@@ -23,7 +23,7 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: 
+  with_items:
     - kubelet-{{ kubernetes_version }}
     - kubectl-{{ kubernetes_version }}
     - kubernetes-cni-{{ kubernetes_cni_version }}*

--- a/config_management/roles/kubernetes-start/tasks/main.yml
+++ b/config_management/roles/kubernetes-start/tasks/main.yml
@@ -15,7 +15,7 @@
   when: ' {{ play_hosts[0] == inventory_hostname }}'
 
 - name: allow pods to be run on the master (if only node)
-  command: kubectl taint nodes --all dedicated-
+  command: 'kubectl --kubeconfig /etc/kubernetes/admin.conf taint nodes --all {{ (kubernetes_version < "1.6") | ternary("", "node-role.kubernetes.io/master:NoSchedule-" }}'
   when: '{{ play_hosts | length }} == 1'
 
 - name:  kubeadm join on workers
@@ -23,7 +23,7 @@
   when: ' {{ play_hosts[0] != inventory_hostname }}'
 
 - name: list kubernetes' pods
-  command: kubectl get pods --all-namespaces
+  command: kubectl --kubeconfig /etc/kubernetes/admin.conf get pods --all-namespaces
   when: ' {{ play_hosts[0] == inventory_hostname }}'
   changed_when: false
   register: kubectl_get_pods

--- a/config_management/roles/kubernetes-start/tasks/main.yml
+++ b/config_management/roles/kubernetes-start/tasks/main.yml
@@ -19,7 +19,7 @@
   when: '{{ play_hosts | length }} == 1'
 
 - name:  kubeadm join on workers
-  command: "kubeadm join --token={{ kubernetes_token }} {{ hostvars[play_hosts[0]].private_ip }}"
+  command: 'kubeadm join --token={{ kubernetes_token }} {{ hostvars[play_hosts[0]].private_ip }}{{ (kubernetes_version > "1.6") | ternary(":6443", "") }}'
   when: ' {{ play_hosts[0] != inventory_hostname }}'
 
 - name: list kubernetes' pods

--- a/config_management/roles/sock-shop/tasks/tasks.yml
+++ b/config_management/roles/sock-shop/tasks/tasks.yml
@@ -4,13 +4,13 @@
 # - kubernetes
 
 - name: create sock-shop namespace in k8s
-  command: kubectl create namespace sock-shop
+  command: kubectl --kubeconfig /etc/kubernetes/admin.conf create namespace sock-shop
 
 - name: create sock-shop in k8s
-  command: kubectl apply -n sock-shop -f "https://github.com/microservices-demo/microservices-demo/blob/master/deploy/kubernetes/complete-demo.yaml?raw=true"
+  command: kubectl --kubeconfig /etc/kubernetes/admin.conf apply -n sock-shop -f "https://github.com/microservices-demo/microservices-demo/blob/master/deploy/kubernetes/complete-demo.yaml?raw=true"
 
 - name: describe front-end service
-  command: kubectl describe svc front-end -n sock-shop
+  command: kubectl --kubeconfig /etc/kubernetes/admin.conf describe svc front-end -n sock-shop
   changed_when: false
   register: kubectl_describe_svc_frontend
   tags:
@@ -22,7 +22,7 @@
     - output
 
 - name: list sock-shop k8s' pods
-  command: kubectl get pods -n sock-shop
+  command: kubectl --kubeconfig /etc/kubernetes/admin.conf get pods -n sock-shop
   changed_when: false
   register: kubectl_get_pods
   tags:

--- a/config_management/roles/weave-kube/tasks/main.yml
+++ b/config_management/roles/weave-kube/tasks/main.yml
@@ -2,11 +2,11 @@
 # Set up Weave Kube on top of Kubernetes.
 
 - name: configure weave net's cni plugin
-  command: kubectl apply -f https://git.io/weave-kube
+  command: kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://git.io/weave-kube
   when: ' {{ play_hosts[0] == inventory_hostname }}'
 
 - name: list kubernetes' pods
-  command: kubectl get pods --all-namespaces
+  command: kubectl --kubeconfig /etc/kubernetes/admin.conf get pods --all-namespaces
   when: ' {{ play_hosts[0] == inventory_hostname }}'
   changed_when: false
   register: kubectl_get_pods

--- a/config_management/roles/weave-net-sources/tasks/main.yml
+++ b/config_management/roles/weave-net-sources/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: check if weave net has been checked out
   become: false  # Run as SSH-user
-  stat: 
+  stat:
     path: $HOME/src/github.com/weaveworks/weave
   register: weave
   failed_when: false

--- a/config_management/roles/weave-net-utilities/tasks/main.yml
+++ b/config_management/roles/weave-net-utilities/tasks/main.yml
@@ -4,7 +4,7 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: 
+  with_items:
     - jq
 
 - name: install ethtool (used by the weave script)
@@ -12,7 +12,7 @@
     name: "{{ item }}"
     install_recommends: no
     state: present
-  with_items: 
+  with_items:
     - ethtool
 
 - name: install nsenter (used by the weave script)
@@ -22,7 +22,7 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: 
+  with_items:
     - python-pip
 
 - name: install docker-py (for docker_image)
@@ -34,7 +34,7 @@
   docker_image:
     name: '{{ item }}'
     state: present
-  with_items: 
+  with_items:
     - alpine
     - aanand/docker-dnsutils
     - weaveworks/hello-world

--- a/config_management/setup_weave-kube.yml
+++ b/config_management/setup_weave-kube.yml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Install Docker and Kubernetes, and configure Kubernetes to 
+# Install Docker and Kubernetes, and configure Kubernetes to
 # use Weave Net's CNI plugin (a.k.a. Weave Kube).
 #
 # See also:
@@ -13,7 +13,7 @@
   gather_facts: false  # required in case Python is not available on the host
   become: true
   become_user: root
-  
+
   pre_tasks:
     - include: library/setup_ansible_dependencies.yml
 

--- a/config_management/setup_weave-net_dev.yml
+++ b/config_management/setup_weave-net_dev.yml
@@ -8,7 +8,7 @@
   gather_facts: false  # required in case Python is not available on the host
   become: true
   become_user: root
-  
+
   pre_tasks:
     - include: library/setup_ansible_dependencies.yml
 

--- a/config_management/setup_weave-net_test.yml
+++ b/config_management/setup_weave-net_test.yml
@@ -8,7 +8,7 @@
   gather_facts: false  # required in case Python is not available on the host
   become: true
   become_user: root
-  
+
   pre_tasks:
     - include: library/setup_ansible_dependencies.yml
 


### PR DESCRIPTION
@marccarre these are the changes I had to make to make our playbooks work with the current unstable packages... I've not attempted to clean this up, as I'm not sure what would be the best way to go about it.