### PR TITLE
Add --insecure-registry to docker.conf

### DIFF
--- a/config_management/roles/docker-configuration/files/docker.conf
+++ b/config_management/roles/docker-configuration/files/docker.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/docker daemon -H fd:// -H unix:///var/run/alt-docker.sock -H tcp://0.0.0.0:2375 -s overlay --insecure-registry "weave-ci-registry:5000"

--- a/config_management/roles/docker-configuration/files/docker_over_tcp.conf
+++ b/config_management/roles/docker-configuration/files/docker_over_tcp.conf
@@ -1,3 +1,0 @@
-[Service]
-ExecStart=
-ExecStart=/usr/bin/docker daemon -H fd:// -H unix:///var/run/alt-docker.sock -H tcp://0.0.0.0:2375 -s overlay

--- a/config_management/roles/docker-configuration/tasks/main.yml
+++ b/config_management/roles/docker-configuration/tasks/main.yml
@@ -21,14 +21,14 @@
 
 - name: enable docker remote api over tcp
   copy:
-    src: "{{ role_path }}/files/docker_over_tcp.conf"
-    dest: /etc/systemd/system/docker.service.d/docker_over_tcp.conf
-  register: docker_over_tcp
+    src: "{{ role_path }}/files/docker.conf"
+    dest: /etc/systemd/system/docker.service.d/docker.conf
+  register: docker_conf
 
 - name: restart docker service
   systemd:
     name: docker
     state: restarted
-    daemon_reload: yes  # ensure docker_over_tcp.conf is picked up.
+    daemon_reload: yes  # ensure docker.conf is picked up.
     enabled: yes
-  when: docker_over_tcp.changed
+  when: docker_conf.changed


### PR DESCRIPTION
The flag ensures that, when pulling from (or pushing to) a remote registry, HTTP instead of HTTPS used.

Otherwise, in Weave Net smoke tests we would need to setup CAs on each host.

Required by https://github.com/weaveworks/weave/pull/2727.