### PR TITLE
Lock kubeadm's Kubernetes version.

### DIFF
--- a/config_management/roles/kubernetes-start/tasks/main.yml
+++ b/config_management/roles/kubernetes-start/tasks/main.yml
@@ -10,13 +10,14 @@
     state: restarted
     enabled: yes
 
-- name: kubeadm init on the master
-  command: 'kubeadm init --token={{ kubernetes_token }}'
-  when: ' {{ play_hosts[0] == inventory_hostname }}'
-
 - name: optionally set kubeconfig option
   set_fact:
     kubeconfig: '{{ (kubernetes_version >= "1.5.4") | ternary("--kubeconfig /etc/kubernetes/admin.conf", "") }}'
+    kubernetes_version_option: '{{ (kubernetes_version >= "1.6") | ternary("kubernetes_version", "use-kubernetes-version") }}'
+
+- name: kubeadm init on the master
+  command: 'kubeadm init --{{ kubernetes_version_option }}=v{{ kubernetes_version }} --token={{ kubernetes_token }}'
+  when: ' {{ play_hosts[0] == inventory_hostname }}'
 
 - name: allow pods to be run on the master (if only node)
   command: 'kubectl {{ kubeconfig }} taint nodes --all {{ (kubernetes_version < "1.6") | ternary("dedicated-", "node-role.kubernetes.io/master:NoSchedule-") }}'

--- a/provisioning/setup.sh
+++ b/provisioning/setup.sh
@@ -308,6 +308,7 @@ Usage:
 Examples:
   $ tf_ssh 1
   $ tf_ssh 1 -o LogLevel VERBOSE
+  $ tf_ssh 1 -i ~/.ssh/custom_private_key_id_rsa
 Available machines:
 EOF
     cat -n >&2 <<<"$(terraform output public_etc_hosts)"

--- a/provisioning/setup.sh
+++ b/provisioning/setup.sh
@@ -333,7 +333,7 @@ Usage:
 Examples:
   $ tf_ansi setup_weave-net_dev
   $ tf_ansi 1
-  $ tf_ansi 1 -vvv
+  $ tf_ansi 1 -vvv --private-key=~/.ssh/custom_private_key_id_rsa
   $ tf_ansi setup_weave-kube --extra-vars "docker_version=1.12.6 kubernetes_version=1.5.6"
 Available playbooks:
 EOF


### PR DESCRIPTION
**Changelog**:
- lock `kubeadm`'s Kubernetes version. Without this change, `kubeadm` typically upgrades whichever version of Kubernetes is installed, sometimes leading to conflicts in between components' version.
- improved usage for `tf_ansi` and `tf_ssh` helper commands.