### PR TITLE
Haskell build image

### DIFF
--- a/build/haskell/Dockerfile
+++ b/build/haskell/Dockerfile
@@ -1,0 +1,4 @@
+FROM fpco/stack-build:lts-8.9
+COPY build.sh /
+COPY copy-libraries /usr/local/bin/
+ENTRYPOINT ["/build.sh"]

--- a/build/haskell/build.sh
+++ b/build/haskell/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# Build a static Haskell binary using stack.
+
+set -eu
+
+if [ -z "${SRC_PATH:-}" ]; then
+    echo "Must set \$SRC_PATH."
+    exit 1
+fi
+
+make -C $SRC_PATH BUILD_IN_CONTAINER=false $*

--- a/build/haskell/copy-libraries
+++ b/build/haskell/copy-libraries
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copy dynamically linked libraries for a binary, so we can assemble a Docker
+# image.
+#
+# Run with:
+#   copy-libraries /path/to/binary /output/dir
+#
+# Dependencies:
+# - awk
+# - cp
+# - grep
+# - ldd
+# - mkdir
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Path to a Linux binary that we're going to run in the container.
+binary_path="${1}"
+# Path to directory to write the output to.
+output_dir="${2}"
+
+exe_name=$(basename "${binary_path}")
+
+# Identify linked libraries.
+libraries=( $( ldd "${binary_path}" | awk '{print $(NF-1)}' | grep -v '=>' ) )
+# Add /bin/sh, which we need for Docker imports.
+libraries+=('/bin/sh')
+
+mkdir -p "${output_dir}"
+
+# Copy executable and all needed libraries into temporary directory.
+cp "${binary_path}" "${output_dir}/${exe_name}"
+for lib in "${libraries[@]}"; do
+    mkdir -p "${output_dir}/$(dirname "$lib")"
+    # Need -L to make sure we get actual libraries & binaries, not symlinks to
+    # them.
+    cp -L "${lib}" "${output_dir}/${lib}"
+done

--- a/build/haskell/copy-libraries
+++ b/build/haskell/copy-libraries
@@ -25,7 +25,7 @@ output_dir="${2}"
 exe_name=$(basename "${binary_path}")
 
 # Identify linked libraries.
-libraries=( $( ldd "${binary_path}" | awk '{print $(NF-1)}' | grep -v '=>' ) )
+libraries=($(ldd "${binary_path}" | awk '{print $(NF-1)}' | grep -v '=>'))
 # Add /bin/sh, which we need for Docker imports.
 libraries+=('/bin/sh')
 


### PR DESCRIPTION
See https://github.com/weaveworks-experiments/compare-revisions/pull/1 for an illustration.

The reason it's all so complicated is that `stack` _already_ does dockerized builds (e.g. `stack --docker build`), so it's a matter of reverse engineering what it does.