### PR TITLE
Upgrade default Go version to 1.8.1.

### DIFF
--- a/config_management/group_vars/all
+++ b/config_management/group_vars/all
@@ -1,5 +1,5 @@
 ---
-go_version: 1.7.4
+go_version: 1.8.1
 terraform_version: 0.8.5
 docker_version: 1.11.2
 docker_install_role: 'docker-from-get.docker.com'

--- a/provisioning/setup.sh
+++ b/provisioning/setup.sh
@@ -348,7 +348,7 @@ function tf_ansi() {
     shift # Drop the first argument to allow passing other arguments to Ansible using "$@" -- see below.
     if [[ "$id" =~ ^[0-9]+$ ]]; then
         local playbooks=(../../config_management/*.yml)
-        local path="${playbooks[(($id-1))]}" # Select the ith entry in the list of playbooks (0-based).
+        local path="${playbooks[(($id - 1))]}" # Select the ith entry in the list of playbooks (0-based).
     else
         local path="$(dirname "${BASH_SOURCE[0]}")/../../config_management/$id.yml"
     fi


### PR DESCRIPTION
In order to benefit from latest release's changes, e.g. `time.Until`.
See also: https://golang.org/doc/go1.8