### PR TITLE
More shfmt updates

### DIFF
--- a/integration/assert.sh
+++ b/integration/assert.sh
@@ -108,7 +108,7 @@ assert_end() {
 
 assert() {
     # assert <command> <expected stdout> [stdin]
-    ((tests_ran++))|| :
+    ((tests_ran++)) || :
     [[ -z "$DISCOVERONLY" ]] || return
     expected=$(echo -ne "${2:-}")
     result="$(eval "$1" 2>/dev/null <<<"${3:-}")" || true
@@ -124,7 +124,7 @@ assert() {
 
 assert_raises() {
     # assert_raises <command> <expected code> [stdin]
-    ((tests_ran++))|| :
+    ((tests_ran++)) || :
     [[ -z "$DISCOVERONLY" ]] || return
     status=0
     (eval "$1" <<<"${3:-}") >/dev/null 2>&1 || status=$?
@@ -146,7 +146,7 @@ _assert_fail() {
         exit 1
     fi
     tests_errors[$tests_failed]="$report"
-    ((tests_failed++))|| :
+    ((tests_failed++)) || :
 }
 
 skip_if() {

--- a/lint
+++ b/lint
@@ -113,7 +113,7 @@ lint_sh() {
     local filename="$1"
     local lint_result=0
 
-    if ! diff <(shfmt -i 4 "${filename}") "${filename}" >/dev/null; then
+    if ! diff <(shfmt -i 4 "${filename}") "${filename}"; then
         lint_result=1
         echo "${filename}: run shfmt -i 4 -w ${filename}"
     fi
@@ -131,7 +131,7 @@ lint_tf() {
     local filename="$1"
     local lint_result=0
 
-    if ! diff <(hclfmt "${filename}") "${filename}" >/dev/null; then
+    if ! diff <(hclfmt "${filename}") "${filename}"; then
         lint_result=1
         echo "${filename}: run hclfmt -w ${filename}"
     fi


### PR DESCRIPTION
The previous PR (https://github.com/weaveworks/build-tools/pull/95) missed some shfmt fixes. This PR also prints the shfmt diff: this will help to fix future shfmt issues.

This should fix the failures detected on https://circleci.com/gh/kinvolk/tcptracer-bpf/423. The CI is green on https://circleci.com/gh/kinvolk/tcptracer-bpf/426

Needed for
- https://github.com/weaveworks/tcptracer-bpf/pull/37
- https://github.com/weaveworks/tcptracer-bpf/pull/39

@2opremio PTAL