### PR TITLE
shellcheck: fix escaping issue

### DIFF
--- a/dependencies/list_os_images.sh
+++ b/dependencies/list_os_images.sh
@@ -8,11 +8,11 @@ Dependencies:
   - gcloud, Google Cloud Platform's CLI
   - aws,
 Usage: 
-  $ ./$(basename "$0") PROVIDER OS
+  \$ ./$(basename "$0") PROVIDER OS
   PROVIDER={gcp}
   OS={ubuntu|debian|centos}
 Example: 
-  $ ./$(basename "$0") gcp ubuntu
+  \$ ./$(basename "$0") gcp ubuntu
   ubuntu-os-cloud/ubuntu-1204-lts
   ubuntu-os-cloud/ubuntu-1404-lts
   ubuntu-os-cloud/ubuntu-1604-lts

--- a/provisioning/setup.sh
+++ b/provisioning/setup.sh
@@ -304,11 +304,11 @@ function tf_ssh_usage() {
 ERROR: $1
 
 Usage:
-  $ tf_ssh <host ID (1-based)> [OPTION]...
+  \$ tf_ssh <host ID (1-based)> [OPTION]...
 Examples:
-  $ tf_ssh 1
-  $ tf_ssh 1 -o LogLevel VERBOSE
-  $ tf_ssh 1 -i ~/.ssh/custom_private_key_id_rsa
+  \$ tf_ssh 1
+  \$ tf_ssh 1 -o LogLevel VERBOSE
+  \$ tf_ssh 1 -i ~/.ssh/custom_private_key_id_rsa
 Available machines:
 EOF
     cat -n >&2 <<<"$(terraform output public_etc_hosts)"
@@ -330,12 +330,12 @@ function tf_ansi_usage() {
 ERROR: $1
 
 Usage:
-  $ tf_ansi <playbook or playbook ID (1-based)> [OPTION]...
+  \$ tf_ansi <playbook or playbook ID (1-based)> [OPTION]...
 Examples:
-  $ tf_ansi setup_weave-net_dev
-  $ tf_ansi 1
-  $ tf_ansi 1 -vvv --private-key=~/.ssh/custom_private_key_id_rsa
-  $ tf_ansi setup_weave-kube --extra-vars "docker_version=1.12.6 kubernetes_version=1.5.6"
+  \$ tf_ansi setup_weave-net_dev
+  \$ tf_ansi 1
+  \$ tf_ansi 1 -vvv --private-key=~/.ssh/custom_private_key_id_rsa
+  \$ tf_ansi setup_weave-kube --extra-vars "docker_version=1.12.6 kubernetes_version=1.5.6"
 Available playbooks:
 EOF
     cat -n >&2 <<<"$(for file in "$(dirname "${BASH_SOURCE[0]}")"/../../config_management/*.yml; do basename "$file" | sed 's/.yml//'; done)"


### PR DESCRIPTION
Symptoms:
```
./tools/dependencies/list_os_images.sh:11:3: $ must be escaped or followed by a literal
./tools/provisioning/setup.sh:307:3: $ must be escaped or followed by a literal
```

Needed for https://github.com/weaveworks/tcptracer-bpf/pull/39