### PR TITLE
Update Docker installation

### DIFF
--- a/config_management/group_vars/all
+++ b/config_management/group_vars/all
@@ -1,8 +1,8 @@
 ---
 go_version: 1.8.1
 terraform_version: 0.8.5
-docker_version: 1.11.2
-docker_install_role: 'docker-from-get.docker.com'
+docker_version: 17.06
+docker_install_role: 'docker-from-docker-ce-repo'
 kubernetes_version: 1.6.1
 kubernetes_cni_version: 0.5.1
 kubernetes_token: '123456.0123456789123456'

--- a/config_management/roles/docker-configuration/files/docker.conf
+++ b/config_management/roles/docker-configuration/files/docker.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/docker daemon -H fd:// -H unix:///var/run/alt-docker.sock -H tcp://0.0.0.0:2375 -s overlay --insecure-registry "weave-ci-registry:5000"
+ExecStart=/usr/bin/dockerd -H fd:// -H unix:///var/run/alt-docker.sock -H tcp://0.0.0.0:2375 -s overlay --insecure-registry "weave-ci-registry:5000"

--- a/config_management/roles/docker-from-docker-ce-repo/tasks/debian.yml
+++ b/config_management/roles/docker-from-docker-ce-repo/tasks/debian.yml
@@ -1,0 +1,35 @@
+---
+# Debian / Ubuntu specific:
+
+- name: install dependencies for docker repository
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - apt-transport-https
+    - ca-certificates
+
+- name: add apt key for the docker repository
+  apt_key:
+    keyserver: hkp://ha.pool.sks-keyservers.net:80
+    id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+    state: present
+  register: apt_key_docker_repo
+
+- name: add docker's apt repository ({{ ansible_distribution | lower }}-{{ ansible_distribution_release }})
+  apt_repository:
+    repo: deb https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename|lower }} stable
+    state: present
+  register: apt_docker_repo
+
+- name: update apt's cache
+  apt:
+    update_cache: yes
+  when: apt_key_docker_repo.changed or apt_docker_repo.changed
+
+- name: install docker-engine
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - docker-ce={{ docker_version }}*

--- a/config_management/roles/docker-from-docker-ce-repo/tasks/main.yml
+++ b/config_management/roles/docker-from-docker-ce-repo/tasks/main.yml
@@ -1,29 +1,10 @@
-# Docker installation from Docker's CentOS Community Edition
-# See also: https://docs.docker.com/engine/installation/linux/centos/
+---
+# Set up Docker
+# See also: https://docs.docker.com/engine/installation/linux/ubuntulinux/#install
 
-- name: remove all potentially pre existing packages
-  yum:
-    name: '{{ item }}'
-    state: absent
-  with_items:
-    - docker
-    - docker-common
-    - container-selinux
-    - docker-selinux
-    - docker-engine
+# Distribution-specific tasks:
+- include: debian.yml
+  when: ansible_os_family == "Debian"
 
-- name: install yum-utils
-  yum:
-    name: yum-utils
-    state: present
-
-- name: add docker ce repo
-  command: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-
-# Note that Docker CE versions do not follow regular Docker versions, but look
-# like, for example: "17.03.0.el7"
-- name: install docker
-  yum:
-    name: 'docker-ce-{{ docker_version }}'
-    update_cache: yes
-    state: present
+- include: redhat.yml
+  when: ansible_os_family == "RedHat"

--- a/config_management/roles/docker-from-docker-ce-repo/tasks/redhat.yml
+++ b/config_management/roles/docker-from-docker-ce-repo/tasks/redhat.yml
@@ -1,0 +1,29 @@
+# Docker installation from Docker's CentOS Community Edition
+# See also: https://docs.docker.com/engine/installation/linux/centos/
+
+- name: remove all potentially pre existing packages
+  yum:
+    name: '{{ item }}'
+    state: absent
+  with_items:
+    - docker
+    - docker-common
+    - container-selinux
+    - docker-selinux
+    - docker-engine
+
+- name: install yum-utils
+  yum:
+    name: yum-utils
+    state: present
+
+- name: add docker ce repo
+  command: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+
+# Note that Docker CE versions do not follow regular Docker versions, but look
+# like, for example: "17.03.0.el7"
+- name: install docker
+  yum:
+    name: 'docker-ce-{{ docker_version }}'
+    update_cache: yes
+    state: present

--- a/config_management/roles/docker-from-get.docker.com/tasks/debian.yml
+++ b/config_management/roles/docker-from-get.docker.com/tasks/debian.yml
@@ -5,4 +5,4 @@
   shell: curl -sSL https://get.docker.com/gpg | sudo apt-key add -
 
 - name: install docker
-  shell: 'curl -sSL https://get.docker.com/ | sed -e s/docker-engine/docker-engine={{ docker_version }}*/ | sh'
+  shell: 'curl -sSL https://get.docker.com/ | sed -e s/docker-engine/docker-engine={{ docker_version }}*/ -e s/docker-ce/docker-ce={{ docker_version }}*/ | sh'


### PR DESCRIPTION
Version 1.13, which we were using, no longer installs via get.docker.com

I couldn't figure out how to fix the 1.13 install, but it's a very small percentage of our users so I bumped the default to 17.06 and made that work, based on [Docker's instructions](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#install-using-the-repository)