### PR TITLE
Override apt daily job to not run immediately on boot

### DIFF
--- a/config_management/roles/dev-tools/files/apt-daily.timer.conf
+++ b/config_management/roles/dev-tools/files/apt-daily.timer.conf
@@ -1,0 +1,2 @@
+[Timer]
+Persistent=false

--- a/config_management/roles/dev-tools/tasks/main.yml
+++ b/config_management/roles/dev-tools/tasks/main.yml
@@ -38,3 +38,11 @@
     dest: /usr/bin
     mode: 0555
     creates: /usr/bin/terraform
+
+# Ubuntu runs an apt update process that will run on first boot from image.
+# This is of questionable value when the machines are only going to live for a few minutes.
+# If you leave them on they will run the process daily.
+# Also we have seen the update process create a 'defunct' process which then throws off Weave Net smoke-test checks.
+# So, we override the 'persistent' setting so it will still run at the scheduled time but will not try to catch up on first boot.
+- name: copy apt daily override
+  copy: src=apt-daily.timer.conf dest=/etc/systemd/system/apt-daily.timer.d/


### PR DESCRIPTION
This slows down boot and is of questionable value when the machines are only going to live for a few minutes.  If you leave them on they will run the process daily.

Also we have seen the update process create a 'defunct' process which then throws off Weave Net smoke-test checks.