### PR TITLE
Check for errors when pushing images in parallel

### DIFF
--- a/push-images
+++ b/push-images
@@ -45,13 +45,10 @@ for image in ${IMAGES}; do
     fi
 done
 
-EC=0
 for p in $pids; do
     if ! wait $p; then
-        echo "Process $p failed with $?"
-        EC=1
+        exit 1
     fi
 done
 
 wait
-exit $EC

--- a/push-images
+++ b/push-images
@@ -33,7 +33,7 @@ for image in ${IMAGES}; do
     fi
     echo "Will push ${image}:${IMAGE_TAG}"
     docker push "${image}:${IMAGE_TAG}" &
-    pids+=" $!"
+    pids="$pids $!"
 
     if [ -z "$NO_DOCKER_HUB" ]; then
         # remove the quey prefix and push to docker hub
@@ -41,14 +41,13 @@ for image in ${IMAGES}; do
         docker tag "${image}:${IMAGE_TAG}" "${docker_hub_image}:${IMAGE_TAG}"
         echo "Will push ${docker_hub_image}:${IMAGE_TAG}"
         docker push "${docker_hub_image}:${IMAGE_TAG}" &
-        pids+=" $!"
+        pids="$pids $!"
     fi
 done
 
+# Wait individually for tasks so we fail-exit on any non-zero return code
 for p in $pids; do
-    if ! wait $p; then
-        exit 1
-    fi
+    wait $p
 done
 
 wait

--- a/push-images
+++ b/push-images
@@ -26,25 +26,32 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-push_image() {
-    local image="$1"
-    docker push "${image}:${IMAGE_TAG}"
-}
-
+pids=""
 for image in ${IMAGES}; do
     if [[ "$image" == *"build"* ]]; then
         continue
     fi
     echo "Will push ${image}:${IMAGE_TAG}"
-    push_image "${image}" &
+    docker push "${image}:${IMAGE_TAG}" &
+    pids+=" $!"
 
     if [ -z "$NO_DOCKER_HUB" ]; then
         # remove the quey prefix and push to docker hub
         docker_hub_image=${image#$QUAY_PREFIX}
         docker tag "${image}:${IMAGE_TAG}" "${docker_hub_image}:${IMAGE_TAG}"
         echo "Will push ${docker_hub_image}:${IMAGE_TAG}"
-        docker push "${docker_hub_image}:${IMAGE_TAG}"
+        docker push "${docker_hub_image}:${IMAGE_TAG}" &
+        pids+=" $!"
+    fi
+done
+
+EC=0
+for p in $pids; do
+    if ! wait $p; then
+        echo "Process $p failed with $?"
+        EC=1
     fi
 done
 
 wait
+exit $EC


### PR DESCRIPTION
@rade spotted that an image failed to push, but the build still succeeded.

We could use `wait -n` to wait for subshells, however that requries bash >= 4.3, and OSX still ships with 3.2.57.