### PR TITLE
Gocyclo should return error code if issues detected

### DIFF
--- a/build/golang/Dockerfile
+++ b/build/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.0-stretch
+FROM golang:1.9.2-stretch
 RUN apt-get update && \
     apt-get install -y \
       curl \

--- a/lint
+++ b/lint
@@ -95,6 +95,7 @@ lint_go() {
     # it just warns.
     if type gocyclo >/dev/null 2>&1; then
         gocyclo -over 25 "${filename}" | while read -r line; do
+            lint_result=1
             echo "${filename}": higher than 25 cyclomatic complexity - "${line}"
         done
     fi

--- a/lint
+++ b/lint
@@ -94,10 +94,11 @@ lint_go() {
     # don't have it installed.  Also never blocks a commit,
     # it just warns.
     if type gocyclo >/dev/null 2>&1; then
-        gocyclo -over 25 "${filename}" | while read -r line; do
+        cycloutput=$(gocyclo -over 25 "${filename}")
+        if [ -n "$cycloutput" ]; then
             lint_result=1
-            echo "${filename}": higher than 25 cyclomatic complexity - "${line}"
-        done
+            echo "${filename}": higher than 25 cyclomatic complexity - "${cycloutput}"
+        fi
     fi
 
     return $lint_result


### PR DESCRIPTION
Before this change any `gocyclo` issue did not return an error and builds using it weren't aborting.