### PR TITLE
Revert "Gocyclo should return error code if issues detected"

### DIFF
--- a/build/golang/Dockerfile
+++ b/build/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.0-stretch
+FROM golang:1.9.2-stretch
 RUN apt-get update && \
     apt-get install -y \
       curl \

--- a/build/golang/Dockerfile
+++ b/build/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.2-stretch
+FROM golang:1.8.0-stretch
 RUN apt-get update && \
     apt-get install -y \
       curl \

--- a/lint
+++ b/lint
@@ -94,11 +94,9 @@ lint_go() {
     # don't have it installed.  Also never blocks a commit,
     # it just warns.
     if type gocyclo >/dev/null 2>&1; then
-        cycloutput=$(gocyclo -over 25 "${filename}")
-        if [ -n "$cycloutput" ]; then
-            lint_result=1
-            echo "${filename}": higher than 25 cyclomatic complexity - "${cycloutput}"
-        fi
+        gocyclo -over 25 "${filename}" | while read -r line; do
+            echo "${filename}": higher than 25 cyclomatic complexity - "${line}"
+        done
     fi
 
     return $lint_result


### PR DESCRIPTION
Reverts weaveworks/build-tools#120

`gocyclo` checks are deliberately optional and do not block the build. Totally open to changing this, but should be done after consultation w/ the whole team.