### PR TITLE
Use golang:1.10.0-stretch image

### DIFF
--- a/build/golang/Dockerfile
+++ b/build/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.2-stretch
+FROM golang:1.10.0-stretch
 RUN apt-get update && \
     apt-get install -y \
       curl \


### PR DESCRIPTION
Should fix errors like the below one in `service-conf`:
```
Step 4 : RUN go get -tags netgo github.com/prometheus/prometheus/cmd/promtool && 	cd /go/src/github.com/prometheus/prometheus && 	git checkout v1.8.1 && 	go install -tags netgo github.com/prometheus/prometheus/cmd/promtool && 	rm -rf /go/pkg /go/src
 ---> Running in de05cd788847
src/github.com/prometheus/prometheus/discovery/targetgroup/targetgroup.go:83:5: dec.DisallowUnknownFields undefined (type *json.Decoder has no field or method DisallowUnknownFields)
The command '/bin/sh -c go get -tags netgo github.com/prometheus/prometheus/cmd/promtool && 	cd /go/src/github.com/prometheus/prometheus && 	git checkout v1.8.1 && 	go install -tags netgo github.com/prometheus/prometheus/cmd/promtool && 	rm -rf /go/pkg /go/src' returned a non-zero code: 2
make: *** [service-conf-build/.uptodate] Error 1
```

See also: weaveworks/service-conf/issues/1954