### PR TITLE
Add opencontainers labels to dockerfiles

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -5,13 +5,14 @@
 # All this must go at top of file I'm afraid.
 IMAGE_PREFIX := quay.io/weaveworks/build-
 IMAGE_TAG := $(shell ../image-tag)
+GIT_REVISION := $(shell git rev-parse HEAD)
 UPTODATE := .uptodate
 
 # Every directory with a Dockerfile in it builds an image called
 # $(IMAGE_PREFIX)<dirname>. Dependencies (i.e. things that go in the image)
 # still need to be explicitly declared.
 %/$(UPTODATE): %/Dockerfile %/*
-	$(SUDO) docker build -t $(IMAGE_PREFIX)$(shell basename $(@D)) $(@D)/
+	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) -t $(IMAGE_PREFIX)$(shell basename $(@D)) $(@D)/
 	$(SUDO) docker tag $(IMAGE_PREFIX)$(shell basename $(@D)) $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG)
 	touch $@
 

--- a/build/golang/Dockerfile
+++ b/build/golang/Dockerfile
@@ -48,3 +48,10 @@ RUN mkdir -p /var/run/secrets/kubernetes.io/serviceaccount && \
 		touch /var/run/secrets/kubernetes.io/serviceaccount/token
 COPY build.sh /
 ENTRYPOINT ["/build.sh"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="golang" \
+      org.opencontainers.image.source="https://github.com/weaveworks/build-tools/tree/master/build/golang" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/build/haskell/Dockerfile
+++ b/build/haskell/Dockerfile
@@ -2,3 +2,10 @@ FROM fpco/stack-build:lts-8.9
 COPY build.sh /
 COPY copy-libraries /usr/local/bin/
 ENTRYPOINT ["/build.sh"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="haskell" \
+      org.opencontainers.image.source="https://github.com/weaveworks/build-tools/tree/master/build/haskell" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/rebuild-image
+++ b/rebuild-image
@@ -9,6 +9,7 @@ IMAGENAME=$1
 SAVEDNAME=$(echo "$IMAGENAME" | sed "s/[\/\-]/\./g")
 IMAGEDIR=$2
 shift 2
+GIT_REVISION="$(git rev-parse HEAD)"
 
 INPUTFILES=("$@")
 CACHEDIR=$HOME/docker/
@@ -17,7 +18,7 @@ CACHEDIR=$HOME/docker/
 rebuild() {
     mkdir -p "$CACHEDIR"
     rm "$CACHEDIR/$SAVEDNAME"* || true
-    docker build -t "$IMAGENAME" "$IMAGEDIR"
+    docker build --build-arg=revision="$GIT_REVISION" -t "$IMAGENAME" "$IMAGEDIR"
     docker save "$IMAGENAME:latest" | gzip - >"$CACHEDIR/$SAVEDNAME-$CIRCLE_SHA1.gz"
 }
 

--- a/socks/Dockerfile
+++ b/socks/Dockerfile
@@ -1,7 +1,13 @@
 FROM gliderlabs/alpine
-MAINTAINER Weaveworks Inc <help@weave.works>
 WORKDIR /
 COPY proxy /
 EXPOSE 8000
 EXPOSE 8080
 ENTRYPOINT ["/proxy"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="socks" \
+      org.opencontainers.image.source="https://github.com/weaveworks/build-tools/tree/master/socks" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/socks/Makefile
+++ b/socks/Makefile
@@ -2,6 +2,7 @@
 
 IMAGE_TAR=image.tar
 IMAGE_NAME=weaveworks/socksproxy
+GIT_REVISION := $(shell git rev-parse HEAD)
 PROXY_EXE=proxy
 NETGO_CHECK=@strings $@ | grep cgo_stub\\\.go >/dev/null || { \
 	rm $@; \
@@ -15,7 +16,7 @@ NETGO_CHECK=@strings $@ | grep cgo_stub\\\.go >/dev/null || { \
 all: $(IMAGE_TAR)
 
 $(IMAGE_TAR): Dockerfile $(PROXY_EXE)
-	docker build -t $(IMAGE_NAME) .
+	docker build --build-arg=revision=$(GIT_REVISION) -t $(IMAGE_NAME) .
 	docker save $(IMAGE_NAME):latest > $@
 
 $(PROXY_EXE): *.go


### PR DESCRIPTION
Why? What?

- This should ultimately help for image-to-code back references.
- `org.label-schema.*` labels are now deprecated, in favour of `org.opencontainers.image.*` labels.
  See also: https://github.com/opencontainers/image-spec/blob/master/annotations.md#back-compatibility-with-label-schema
- `MAINTAINER` is deprecated, in favour of the `maintainer` label.
- Git revision (`git rev-parse HEAD`) is now injected at `docker build` time.

Testing:

```console
$ docker inspect quay.io/weaveworks/build-golang
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.opencontainers.image.revision": "248def1ba24b8c48dc05f8f46d0f4a9c2a671e5e",
                "org.opencontainers.image.source": "https://github.com/weaveworks/build-tools/tree/master/build/golang",
                "org.opencontainers.image.title": "golang",
                "org.opencontainers.image.vendor": "Weaveworks"
            }
[...]

$ docker inspect quay.io/weaveworks/build-haskell
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.opencontainers.image.revision": "248def1ba24b8c48dc05f8f46d0f4a9c2a671e5e",
                "org.opencontainers.image.source": "https://github.com/weaveworks/build-tools/tree/master/build/haskell",
                "org.opencontainers.image.title": "haskell",
                "org.opencontainers.image.vendor": "Weaveworks"
            }
[...]

$ docker inspect weaveworks/socksproxy
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.opencontainers.image.revision": "248def1ba24b8c48dc05f8f46d0f4a9c2a671e5e",
                "org.opencontainers.image.source": "https://github.com/weaveworks/build-tools/tree/master/socks",
                "org.opencontainers.image.title": "socks",
                "org.opencontainers.image.vendor": "Weaveworks"
            }
[...]

```
