### PR TITLE
tools: Use --filter instead of --regexp with gcloud

### DIFF
--- a/dependencies/list_os_images.sh
+++ b/dependencies/list_os_images.sh
@@ -57,7 +57,7 @@ fi
 
 case "$1" in
     'gcp')
-        gcloud compute images list --standard-images --regexp=".*?$2.*" \
+        gcloud compute images list --standard-images --filter="name~'.*?$2.*'" \
             --format="csv[no-heading][separator=/](selfLink.map().scope(projects).segment(0),family)" \
             | sort -d
         ;;


### PR DESCRIPTION
Using --regexp produces the warnings:

WARNING: Flag --regexp is deprecated. Use --filter="name~'REGEXP'" instead.

Still works!

$ ./tools/dependencies/list_os_images.sh gcp centos
centos-cloud/centos-6
centos-cloud/centos-7