### PR TITLE
Changes to enable weave/scope for power 

### DIFF
--- a/lint
+++ b/lint
@@ -106,9 +106,12 @@ lint_sh() {
     local filename="$1"
     local lint_result=0
 
-    if ! diff -u "${filename}" <(shfmt -i 4 "${filename}"); then
-        lint_result=1
-        echo "${filename}: run shfmt -i 4 -w ${filename}"
+    # Skip shfmt validation, if not installed
+    if type shfmt >/dev/null 2>&1; then
+        if ! diff -u "${filename}" <(shfmt -i 4 "${filename}"); then
+            lint_result=1
+            echo "${filename}: run shfmt -i 4 -w ${filename}"
+        fi
     fi
 
     # the shellcheck is completely optional.  If you don't like it


### PR DESCRIPTION
Modified the lint tools to skip the shfmt check if not installed.

For ppc64le the specific version of shfmt is not available,
hence skipped completely the installation of shfmt tool. Thus this change made.