### PR TITLE
Update socks proxy: context is now part of the Go standard library

### DIFF
--- a/socks/main.go
+++ b/socks/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 	socks5 "github.com/armon/go-socks5"
 	"github.com/weaveworks/common/mflag"
 	"github.com/weaveworks/common/mflagext"
-	"golang.org/x/net/context"
 )
 
 type pacFileParameters struct {


### PR DESCRIPTION
This is to re-do part of weaveworks/scope#3276 in the correct place
