### PR TITLE
Fix golint expects import golang.org/x/lint/golint

### DIFF
--- a/build/golang/Dockerfile
+++ b/build/golang/Dockerfile
@@ -30,7 +30,7 @@ RUN go get -tags netgo \
 		github.com/gogo/protobuf/gogoproto \
 		github.com/gogo/protobuf/protoc-gen-gogoslick \
 		github.com/golang/dep/... \
-		github.com/golang/lint/golint \
+		golang.org/x/lint/golint \
 		github.com/golang/protobuf/protoc-gen-go \
 		github.com/kisielk/errcheck \
 		github.com/mjibson/esc \


### PR DESCRIPTION
Previously, one would get:
```
package github.com/golang/lint/golint: code in directory /go/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
The command '/bin/sh -c go get -tags netgo \
        github.com/FiloSottile/gvt \
        github.com/client9/misspell/cmd/misspell \
        github.com/fatih/hclfmt \
        github.com/fzipp/gocyclo \
        github.com/gogo/protobuf/gogoproto \
        github.com/gogo/protobuf/protoc-gen-gogoslick \
        github.com/golang/dep/... \
        golang.org/x/lint/golint \
        github.com/golang/protobuf/protoc-gen-go \
        github.com/kisielk/errcheck \
        github.com/mjibson/esc \
        github.com/prometheus/prometheus/cmd/promtool && \
        rm -rf /go/pkg /go/src' returned a non-zero code: 1
make: *** [golang/.uptodate] Error 1
```

See also:
- https://circleci.com/gh/weaveworks/build-tools/626
- https://github.com/golang/lint/issues/415
