### PR TITLE
Upgrade build image from golang:1.10.0-strech to 1.11.1-strech

### DIFF
--- a/build/golang/Dockerfile
+++ b/build/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.0-stretch
+FROM golang:1.11.1-stretch
 RUN apt-get update && \
     apt-get install -y \
       curl \


### PR DESCRIPTION
N.B.: [`gofmt` has changed between 1.10 and 1.11](https://golang.org/doc/go1.11#gofmt), which may impact linting in some projects, once switching versions.