### PR TITLE
Update to Go 1.12.1

### DIFF
--- a/build/golang/Dockerfile
+++ b/build/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.1-stretch
+FROM golang:1.12.1-stretch
 RUN apt-get update && \
     apt-get install -y \
       curl \

--- a/lint
+++ b/lint
@@ -65,6 +65,7 @@ spell_check() {
 }
 
 lint_go() {
+    # This function is called on a whole directory containing Go files
     local filename="$1"
     local lint_result=0
 
@@ -73,7 +74,7 @@ lint_go() {
         echo "${filename}: run gofmt -s -w ${filename}"
     fi
 
-    go tool vet "${filename}" || lint_result=$?
+    go vet "${filename}" || lint_result=$?
 
     # golint is completely optional.  If you don't like it
     # don't have it installed.
@@ -185,7 +186,7 @@ lint() {
 
     case "$mimetype.$ext" in
         text/x-shellscript.*) lint_sh "${filename}" || lint_result=1 ;;
-        *.go) lint_go "${filename}" || lint_result=1 ;;
+        *.go) ;; # done at directory level
         *.tf) lint_tf "${filename}" || lint_result=1 ;;
         *.md) lint_md "${filename}" || lint_result=1 ;;
         *.py) lint_py "${filename}" || lint_result=1 ;;
@@ -208,7 +209,7 @@ lint_files() {
     while read -r filename; do
         lint "${filename}" || lint_result=1
     done
-    exit $lint_result
+    return $lint_result
 }
 
 matches_any() {
@@ -239,18 +240,33 @@ filter_out() {
     fi
 }
 
-list_files() {
+lint_directory() {
+    local dirname="$1"
+    local lint_result=0
+    # This test is just checking if there are any Go files in the directory
+    if compgen -G "$dirname/*.go" >/dev/null; then
+        lint_go "${dirname}" || lint_result=1
+    fi
+    ls $dirname/* | filter_out "$LINT_IGNORE_FILE" | lint_files
+    return $lint_result
+}
+
+lint_directories() {
+    local lint_result=0
+    while read -r dirname; do
+        lint_directory "${dirname}" || lint_result=1
+    done
+    exit $lint_result
+}
+
+list_directories() {
     if [ $# -gt 0 ]; then
-        find "$@" \( -name vendor -o -name .git \) -prune -o -type f
-    else
-        git ls-files --exclude-standard | grep -vE '(^|/)vendor/'
+        find "$@" \( -name vendor -o -name .git -o -name .cache -o -name .pkg \) -prune -o -type d
     fi
 }
 
 if [ $# = 1 ] && [ -f "$1" ]; then
     lint "$1"
-elif [ -n "$PARALLEL" ]; then
-    list_files "$@" | filter_out "$LINT_IGNORE_FILE" | xargs -n1 -P16 "$0"
 else
-    list_files "$@" | filter_out "$LINT_IGNORE_FILE" | lint_files
+    list_directories "$@" | lint_directories
 fi


### PR DESCRIPTION
Update the build image and lint script to work with Go 1.12

`go tool vet` has been removed upstream.
`go vet` does not accept a single filename to work on, so I have updated the script to vet a whole directory at once.