### PR TITLE
Update Go build to 1.13.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,9 @@ jobs:
     - checkout
     - run: cd build; make
     - run: docker run --rm -v "$PWD:$PWD" -w "$PWD" --entrypoint sh weaveworks/build-golang -c ./lint .
-    - run: cd cover; make
-    # Socks makefile needs to overwrite Go std library
-    - run: sudo chmod a+wr --recursive /usr/local/go/pkg
-    - run: cd socks; make
-    - run: cd runner; make
+    - run: docker run --rm -v "$PWD/cover:/go/src/cover" -w "/go/src/cover" --entrypoint sh weaveworks/build-golang -c make
+    - run: docker run --rm -v "$PWD/socks:/go/src/socks" -w "/go/src/socks" --entrypoint sh weaveworks/build-golang -c "make proxy"
+    - run: docker run --rm -v "$PWD/runner:/go/src/runner" -w "/go/src/runner" --entrypoint sh weaveworks/build-golang -c make
 
     - deploy:
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
     - checkout
     - run: cd build; make
     - run: docker run --rm -v "$PWD:$PWD" -w "$PWD" --entrypoint sh weaveworks/build-golang -c ./lint .
+    - run: docker run --rm -v "$PWD:$PWD" -w "$PWD" --entrypoint sh weaveworks/build-golang -c ./shell-lint .
     - run: docker run --rm -v "$PWD/cover:/go/src/cover" -w "/go/src/cover" --entrypoint sh weaveworks/build-golang -c make
     - run: docker run --rm -v "$PWD/socks:/go/src/socks" -w "/go/src/socks" --entrypoint sh weaveworks/build-golang -c "make proxy"
     - run: docker run --rm -v "$PWD/runner:/go/src/runner" -w "/go/src/runner" --entrypoint sh weaveworks/build-golang -c make

--- a/build/golang/Dockerfile
+++ b/build/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.1-stretch
+FROM golang:1.13.1-stretch
 RUN apt-get update && \
     apt-get install -y \
       curl \

--- a/cover/Makefile
+++ b/cover/Makefile
@@ -4,7 +4,7 @@ all: cover
 
 cover: *.go
 	go get -tags netgo ./$(@D)
-	go build -ldflags "-extldflags \"-static\" -linkmode=external" -tags netgo -o $@ ./$(@D)
+	go build -ldflags "-extldflags \"-static\"" -tags netgo -o $@ ./$(@D)
 
 clean:
 	rm -rf cover

--- a/lint
+++ b/lint
@@ -22,7 +22,6 @@ LINT_IGNORE_FILE=${LINT_IGNORE_FILE:-".lintignore"}
 
 IGNORE_LINT_COMMENT=
 IGNORE_SPELLINGS=
-PARALLEL=
 while true; do
     case "$1" in
         -nocomment)
@@ -36,10 +35,6 @@ while true; do
         -ignorespelling)
             IGNORE_SPELLINGS="$2,$IGNORE_SPELLINGS"
             shift 2
-            ;;
-        -p)
-            PARALLEL=1
-            shift 1
             ;;
         *)
             break
@@ -247,7 +242,7 @@ lint_directory() {
     if compgen -G "$dirname/*.go" >/dev/null; then
         lint_go "${dirname}" || lint_result=1
     fi
-    ls $dirname/* | filter_out "$LINT_IGNORE_FILE" | lint_files
+    find . -maxdepth 1 "$dirname" | filter_out "$LINT_IGNORE_FILE" | lint_files
     return $lint_result
 }
 

--- a/runner/Makefile
+++ b/runner/Makefile
@@ -4,7 +4,7 @@ all: runner
 
 runner: *.go
 	go get -tags netgo ./$(@D)
-	go build -ldflags "-extldflags \"-static\" -linkmode=external" -tags netgo -o $@ ./$(@D)
+	go build -ldflags "-extldflags \"-static\"" -tags netgo -o $@ ./$(@D)
 
 clean:
 	rm -rf runner

--- a/socks/Makefile
+++ b/socks/Makefile
@@ -21,7 +21,7 @@ $(IMAGE_TAR): Dockerfile $(PROXY_EXE)
 
 $(PROXY_EXE): *.go
 	go get -tags netgo ./$(@D)
-	go build -ldflags "-extldflags \"-static\" -linkmode=external" -tags netgo -o $@ ./$(@D)
+	go build -ldflags "-extldflags \"-static\"" -tags netgo -o $@ ./$(@D)
 	$(NETGO_CHECK)
 
 clean:

--- a/test
+++ b/test
@@ -100,9 +100,6 @@ fi
 
 PACKAGE_BASE=$(go list -e ./)
 
-# Speed up the tests by compiling and installing their dependencies first.
-go test -i "${GO_TEST_ARGS[@]}" "${TESTDIRS[@]}"
-
 run_test() {
     local dir=$1
     if [ -z "$NO_GO_GET" ]; then

--- a/test
+++ b/test
@@ -60,14 +60,14 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-GO_TEST_ARGS=(-tags "${TAGS[@]}" -cpu 4 -timeout $TIMEOUT $VERBOSE)
+GO_TEST_ARGS=(-tags "${TAGS[@]}" -cpu 4 -timeout "$TIMEOUT" "$VERBOSE")
 
 if [ -n "$SLOW" ] || [ -n "$CIRCLECI" ]; then
     SLOW=true
 fi
 
 if [ -n "$SLOW" ]; then
-    GO_TEST_ARGS=("${GO_TEST_ARGS[@]}" ${RACE})
+    GO_TEST_ARGS=("${GO_TEST_ARGS[@]}" "${RACE}")
 
     # shellcheck disable=SC2153
     if [ -n "$COVERDIR" ]; then
@@ -115,7 +115,7 @@ run_test() {
         ) | paste -s -d, -)
         local output
         output=$(mktemp "$coverdir/unit.XXXXXXXXXX")
-        local GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}" -coverprofile=$output -coverpkg=$COVERPKGS)
+        local GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}" "-coverprofile=$output" "-coverpkg=$COVERPKGS")
     fi
 
     local START


### PR DESCRIPTION
This in turn updated shellcheck, so we have a few fixes.

Also some build flags need to change on tools otherwise they crash.
