### PR TITLE
Update Go build image to newer Go and Python

### DIFF
--- a/build/golang/Dockerfile
+++ b/build/golang/Dockerfile
@@ -8,13 +8,16 @@ RUN apt-get update && \
       libprotobuf-dev \
       make \
       protobuf-compiler \
-      python-pip \
+      python3 \
+      python3-pip \
       python-requests \
       python-yaml \
+      libssl-dev \
+      python-openssl \
       shellcheck \
       unzip && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN pip install attrs pyhcl yapf==0.16.2 flake8==3.3.0
+RUN pip3 install attrs==19.2.0 pyhcl yapf==0.16.2 flake8==3.3.0
 RUN curl -fsSLo shfmt https://github.com/mvdan/sh/releases/download/v1.3.0/shfmt_v1.3.0_linux_amd64 && \
 	echo "b1925c2c405458811f0c227266402cf1868b4de529f114722c2e3a5af4ac7bb2  shfmt" | sha256sum -c && \
 	chmod +x shfmt && \

--- a/build/golang/Dockerfile
+++ b/build/golang/Dockerfile
@@ -37,7 +37,7 @@ RUN go get -tags netgo \
 		github.com/golang/protobuf/protoc-gen-go \
 		github.com/kisielk/errcheck \
 		github.com/mjibson/esc \
-		github.com/prometheus/prometheus/cmd/promtool && \
+		&& \
 		rm -rf /go/pkg /go/src
 RUN mkdir protoc && \
 	cd protoc && \

--- a/build/golang/Dockerfile
+++ b/build/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.1-stretch
+FROM golang:1.13.5-stretch
 RUN apt-get update && \
     apt-get install -y \
       curl \


### PR DESCRIPTION
* Update Go to 1.13.5 (latest as of posting)
* Install python 3 instead of obsolete v2.7
* Pin the version of `attrs`
* Stop installing promtool - It's not used by most downstreams, and at least one that does overrides it with a different version.