### PR TITLE
Fix lint script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
     - checkout
     - run: cd build; make
-    - run: docker run --rm -v "$PWD:$PWD" -w "$PWD" --entrypoint sh weaveworks/build-golang -c ./lint .
-    - run: docker run --rm -v "$PWD:$PWD" -w "$PWD" --entrypoint sh weaveworks/build-golang -c ./shell-lint .
-    - run: docker run --rm -v "$PWD/cover:/go/src/cover" -w "/go/src/cover" --entrypoint sh weaveworks/build-golang -c make
-    - run: docker run --rm -v "$PWD/socks:/go/src/socks" -w "/go/src/socks" --entrypoint sh weaveworks/build-golang -c "make proxy"
-    - run: docker run --rm -v "$PWD/runner:/go/src/runner" -w "/go/src/runner" --entrypoint sh weaveworks/build-golang -c make
+    - run: docker run --rm -v "$PWD:$PWD" -w "$PWD" --entrypoint sh weaveworks/build-golang -c "./shell-lint ."
+    - run: docker run --rm -v "$PWD:/go/src" -w "/go/src/cover" --entrypoint sh weaveworks/build-golang -c make
+    - run: docker run --rm -v "$PWD:/go/src" -w "/go/src/socks" --entrypoint sh weaveworks/build-golang -c "make proxy"
+    - run: docker run --rm -v "$PWD:/go/src" -w "/go/src/runner" --entrypoint sh weaveworks/build-golang -c make
+    - run: docker run --rm -v "$PWD:/go/src" -w "/go/src" --entrypoint sh weaveworks/build-golang -c "./lint ./build ./config_management ./cover ./dependencies ./integration ./provisioning ./runner ./scheduler ./socks"
 
     - deploy:
         command: |

--- a/lint
+++ b/lint
@@ -242,7 +242,7 @@ lint_directory() {
     if compgen -G "$dirname/*.go" >/dev/null; then
         lint_go "${dirname}" || lint_result=1
     fi
-    find . -maxdepth 1 "$dirname" | filter_out "$LINT_IGNORE_FILE" | lint_files
+    find "$dirname" -maxdepth 1 | filter_out "$LINT_IGNORE_FILE" | lint_files
     return $lint_result
 }
 

--- a/lint
+++ b/lint
@@ -262,6 +262,8 @@ list_directories() {
 
 if [ $# = 1 ] && [ -f "$1" ]; then
     lint "$1"
+elif [ $# = 0 ]; then
+    list_directories . | lint_directories
 else
     list_directories "$@" | lint_directories
 fi


### PR DESCRIPTION
This is a bit embarrasing: CI was running `lint` (ignoring the `.` that came after), and that did nothing, so constant success.

Fixing `lint` to do all directories when called on its own brought up other problems, which are addressed by doing things slightly differently in CI.