### PR TITLE
Improve lint filtering and error reporting

### DIFF
--- a/dependencies/cross_versions.py
+++ b/dependencies/cross_versions.py
@@ -80,8 +80,9 @@ def cross_versions(config):
 def main(argv):
     try:
         config = _validate_input(argv)
-        print(linesep.join('\t'.join(triple)
-                           for triple in cross_versions(config)))
+        print(
+            linesep.join('\t'.join(triple)
+                         for triple in cross_versions(config)))
     except Exception as e:
         print(str(e))
         exit(_ERROR_RUNTIME)

--- a/lint
+++ b/lint
@@ -248,7 +248,7 @@ lint_directory() {
     if compgen -G "$dirname/*.go" >/dev/null; then
         lint_go "${dirname}" || lint_result=1
     fi
-    find "$dirname" -maxdepth 1 | filter_out "$PATTERNS" | lint_files
+    find "$dirname" -maxdepth 1 | filter_out "$PATTERNS" | lint_files || lint_result=1
     return $lint_result
 }
 

--- a/lint
+++ b/lint
@@ -219,12 +219,16 @@ matches_any() {
     return 1
 }
 
-filter_out() {
+read_patterns() {
     local patterns_file="$1"
     if [ -n "$patterns_file" ] && [ -r "$patterns_file" ]; then
-        local patterns
-        patterns=$(sed '/^#.*$/d ; /^\s*$/d' "$patterns_file") # Remove blank lines and comments before we start iterating.
-        [ -n "$DEBUG" ] && echo >&2 "> Filters:" && echo >&2 "$patterns"
+        sed '/^#.*$/d ; /^\s*$/d' "$patterns_file" # Remove blank lines and comments.
+    fi
+}
+
+filter_out() {
+    local patterns="$1"
+    if [ -n "$patterns" ]; then
         local filtered_out=()
         while read -r filename; do
             matches_any "$filename" "$patterns" && filtered_out+=("$filename") || echo "$filename"
@@ -242,7 +246,7 @@ lint_directory() {
     if compgen -G "$dirname/*.go" >/dev/null; then
         lint_go "${dirname}" || lint_result=1
     fi
-    find "$dirname" -maxdepth 1 | filter_out "$LINT_IGNORE_FILE" | lint_files
+    find "$dirname" -maxdepth 1 | filter_out "$PATTERNS" | lint_files
     return $lint_result
 }
 
@@ -259,6 +263,9 @@ list_directories() {
         find "$@" \( -name vendor -o -name .git -o -name .cache -o -name .pkg \) -prune -o -type d
     fi
 }
+
+PATTERNS=$(read_patterns "$LINT_IGNORE_FILE")
+[ -n "$DEBUG" ] && echo >&2 "> Filters:" && echo >&2 "$PATTERNS"
 
 if [ $# = 1 ] && [ -f "$1" ]; then
     lint "$1"

--- a/lint
+++ b/lint
@@ -261,9 +261,7 @@ lint_directories() {
 }
 
 list_directories() {
-    if [ $# -gt 0 ]; then
-        find "$@" \( -name vendor -o -name .git -o -name .cache -o -name .pkg \) -prune -o -type d
-    fi
+    find "$@" \( -name vendor -o -name .git -o -name .cache -o -name .pkg \) -prune -o -type d
 }
 
 PATTERNS=$(read_patterns "$LINT_IGNORE_FILE")
@@ -271,8 +269,6 @@ PATTERNS=$(read_patterns "$LINT_IGNORE_FILE")
 
 if [ $# = 1 ] && [ -f "$1" ]; then
     lint "$1"
-elif [ $# = 0 ]; then
-    list_directories . | lint_directories
 else
     list_directories "$@" | lint_directories
 fi

--- a/lint
+++ b/lint
@@ -242,6 +242,8 @@ filter_out() {
 lint_directory() {
     local dirname="$1"
     local lint_result=0
+    matches_any "$dirname" "$PATTERNS" && return 0
+    [ -n "$DEBUG" ] && echo >&2 "> Linting directory: $dirname"
     # This test is just checking if there are any Go files in the directory
     if compgen -G "$dirname/*.go" >/dev/null; then
         lint_go "${dirname}" || lint_result=1

--- a/scheduler/main.py
+++ b/scheduler/main.py
@@ -82,14 +82,14 @@ def schedule(test_run, shard_count, shard):
     test_times_dict = dict(test_times)
     test_times.sort(key=operator.itemgetter(1))
 
-    shards = {i: [] for i in xrange(shard_count)}
+    shards = {i: [] for i in range(shard_count)}
     while test_times:
         test_name, time = test_times.pop()
 
         # find shortest shard and put it in that
         s, _ = min(
             ((i, sum(test_times_dict[t] for t in shards[i]))
-             for i in xrange(shard_count)),
+             for i in range(shard_count)),
             key=operator.itemgetter(1))
 
         shards[s].append(test_name)


### PR DESCRIPTION
Fix bug where failure state did not get propagated to the final exit code.
Fix lint errors in Python code that were being hidden.
Skip entire directories that match filter patterns.
Also slight simplification of the zero-arguments case.

Note that filter patterns have to match `./foo/bar` which is different from what happened before #155 