### PR TITLE
Restruct scheduler to use compatible version of werkzeug library

### DIFF
--- a/scheduler/requirements.txt
+++ b/scheduler/requirements.txt
@@ -1,2 +1,3 @@
 flask==0.12.4
 google-api-python-client==1.6.7
+werkzeug<1.0


### PR DESCRIPTION
The flask version specified is not compatible with latest werkzeug.

I have already updated the live app using the instructions at #167 
